### PR TITLE
Add Asynchronous Comment & Likes Viewing + Comment Pinning on Windows Machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# PhpStorm
+.idea/
+
+# Composer
 vendor/
 composer.lock
-config.php
+composer.phar

--- a/commandLine.php
+++ b/commandLine.php
@@ -63,10 +63,11 @@ function newCommand()
     newCommand();
 }
 
-function sendRequest(string $cmd, $values) {
+function sendRequest(string $cmd, $values)
+{
     /** @noinspection PhpComposerExtensionStubsInspection */
     file_put_contents(__DIR__ . '/request', json_encode([
-        'cmd'    => $cmd,
+        'cmd' => $cmd,
         'values' => isset($values) ? $values : [],
     ]));
     logM("Please wait while we ensure the live script has received our request.");

--- a/commandLine.php
+++ b/commandLine.php
@@ -42,6 +42,9 @@ function newCommand()
     } elseif ($line == 'unpin') {
         logM("Please check the other window to see if the unpin succeeded!");
         sendRequest("unpin", null);
+    } elseif ($line == 'pinned') {
+        logM("Please check the other window to see the pinned comment!");
+        sendRequest("pinned", null);
     } elseif ($line == 'url') {
         logM("Please check the other window for your stream url!");
         sendRequest("url", null);
@@ -55,7 +58,7 @@ function newCommand()
         logM("Please check the other window for your viewers list!");
         sendRequest("viewers", null);
     } elseif ($line == 'help') {
-        logM("Commands:\nhelp - Prints this message\nurl - Prints Stream URL\nkey - Prints Stream Key\ninfo - Grabs Stream Info\nviewers - Grabs Stream Viewers\necomments - Enables Comments\ndcomments - Disables Comments\npin - Pins a Comment\nunpin - Unpins a comment if one is pinned\nstop - Stops the Live Stream");
+        logM("Commands:\nhelp - Prints this message\nurl - Prints Stream URL\nkey - Prints Stream Key\ninfo - Grabs Stream Info\nviewers - Grabs Stream Viewers\necomments - Enables Comments\ndcomments - Disables Comments\npin - Pins a Comment\nunpin - Unpins a comment if one is pinned\npinned - Gets the currently pinned comment\nstop - Stops the Live Stream");
     } else {
         logM("Invalid Command. Type \"help\" for help!");
     }

--- a/commandLine.php
+++ b/commandLine.php
@@ -1,0 +1,70 @@
+<?php
+logM("Please wait while while the command line ensures that the live script is properly started!");
+sleep(2);
+logM("Command Line Ready! Type \"help\" for help.");
+newCommand();
+
+
+function newCommand()
+{
+    print "\n> ";
+    $handle = fopen("php://stdin", "r");
+    $line = trim(fgets($handle));
+    if ($line == 'ecomments') {
+        sendRequest("ecomments", null);
+        logM("Enabled Comments!");
+    } elseif ($line == 'dcomments') {
+        sendRequest("dcomments", null);
+        logM("Disabled Comments!");
+    } elseif ($line == 'stop' || $line == 'end') {
+        fclose($handle);
+        logM("Would you like to keep the stream archived for 24 hours? Type \"yes\" to do so or anything else to not.");
+        print "> ";
+        $handle = fopen("php://stdin", "r");
+        $archived = trim(fgets($handle));
+        if ($archived == 'yes') {
+            sendRequest("end", ["no"]);
+        } else {
+            sendRequest("end", ["yes"]);
+        }
+        logM("Command Line Exiting! Stream *should* be ended.");
+        sleep(2);
+        exit();
+    } elseif ($line == 'url') {
+        logM("Please check the other window for your stream url!");
+        sendRequest("url", null);
+    } elseif ($line == 'key') {
+        logM("Please check the other window for your stream key!");
+        sendRequest("key", null);
+    } elseif ($line == 'info') {
+        logM("Please check the other window for your stream info!");
+        sendRequest("info", null);
+    } elseif ($line == 'viewers') {
+        logM("Please check the other window for your viewers list!");
+        sendRequest("viewers", null);
+    } elseif ($line == 'help') {
+        logM("Commands:\nhelp - Prints this message\nurl - Prints Stream URL\nkey - Prints Stream Key\ninfo - Grabs Stream Info\nviewers - Grabs Stream Viewers\necomments - Enables Comments\ndcomments - Disables Comments\nstop - Stops the Live Stream");
+    } else {
+        logM("Invalid Command. Type \"help\" for help!");
+    }
+    fclose($handle);
+    newCommand();
+}
+
+function sendRequest(string $cmd, $values) {
+    /** @noinspection PhpComposerExtensionStubsInspection */
+    file_put_contents(__DIR__ . '/request', json_encode([
+        'cmd'    => $cmd,
+        'values' => isset($values) ? $values : [],
+    ]));
+    logM("Please wait while we ensure the live script has received our request.");
+    sleep(2);
+}
+
+/**
+ * Logs a message in console but it actually uses new lines.
+ */
+function logM($message)
+{
+    print $message . "\n";
+}

--- a/commandLine.php
+++ b/commandLine.php
@@ -30,6 +30,18 @@ function newCommand()
         logM("Command Line Exiting! Stream *should* be ended.");
         sleep(2);
         exit();
+    } elseif ($line == 'pin') {
+        fclose($handle);
+        logM("Please enter the comment id you would like to pin.");
+        print "> ";
+        $handle = fopen("php://stdin", "r");
+        $commentId = trim(fgets($handle));
+        //TODO add comment id length check
+        logM("Assuming that was a valid comment id, the comment should be pinned!");
+        sendRequest("pin", [$commentId]);
+    } elseif ($line == 'unpin') {
+        logM("Please check the other window to see if the unpin succeeded!");
+        sendRequest("unpin", null);
     } elseif ($line == 'url') {
         logM("Please check the other window for your stream url!");
         sendRequest("url", null);
@@ -43,7 +55,7 @@ function newCommand()
         logM("Please check the other window for your viewers list!");
         sendRequest("viewers", null);
     } elseif ($line == 'help') {
-        logM("Commands:\nhelp - Prints this message\nurl - Prints Stream URL\nkey - Prints Stream Key\ninfo - Grabs Stream Info\nviewers - Grabs Stream Viewers\necomments - Enables Comments\ndcomments - Disables Comments\nstop - Stops the Live Stream");
+        logM("Commands:\nhelp - Prints this message\nurl - Prints Stream URL\nkey - Prints Stream Key\ninfo - Grabs Stream Info\nviewers - Grabs Stream Viewers\necomments - Enables Comments\ndcomments - Disables Comments\npin - Pins a Comment\nunpin - Unpins a comment if one is pinned\nstop - Stops the Live Stream");
     } else {
         logM("Invalid Command. Type \"help\" for help!");
     }

--- a/config.php
+++ b/config.php
@@ -1,3 +1,14 @@
 <?php
 define('IG_USERNAME', 'USERNAME');
 define('IG_PASS', 'PASSWORD');
+
+$cfg_callbacks = [
+    'like' => function($user) {
+        $msg = $user->getUsername() . ' liked !';
+        exec('nohup notify-send "' . $msg . '" > /dev/null &');
+    },
+    'comment' => function($user, $comment) {
+        $msg = $user->getUsername() . ' : ' . $comment;
+        exec('nohup notify-send "' . $msg . '" > /dev/null &');
+    }
+];

--- a/goLive.php
+++ b/goLive.php
@@ -43,7 +43,7 @@ try {
     }
 } catch (\Exception $e) {
     if (strpos($e->getMessage(), "Challenge") !== false) {
-        logM("Account Flagged: Please sign out of all phones and try logging into instagram.com from this computer before trying to run this script again!");
+        logM("Account Flagged: Please try logging into instagram.com from this exact computer before trying to run this script again!");
         exit();
     }
     echo 'Error While Logging in to Instagram: ' . $e->getMessage() . "\n";

--- a/goLive.php
+++ b/goLive.php
@@ -12,6 +12,8 @@ require __DIR__ . '/vendor/autoload.php';
 
 use InstagramAPI\Instagram;
 use InstagramAPI\Request\Live;
+use InstagramAPI\Response\Model\User;
+use InstagramAPI\Response\Model\Comment;
 
 require_once 'config.php';
 /////// (Sorta) Config (Still Don't Touch It) ///////
@@ -93,10 +95,10 @@ try {
     echo 'Error While Creating Livestream: ' . $e->getMessage() . "\n";
 }
 
-function addLike(\InstagramAPI\Response\Model\User $user)
+function addLike(User $user)
 {
     global $cfg_callbacks;
-    logM("@".$user->getUsername()." has liked the stream!");
+    logM("@" . $user->getUsername() . " has liked the stream!");
     if (
         $cfg_callbacks &&
         isset($cfg_callbacks['like']) &&
@@ -106,7 +108,7 @@ function addLike(\InstagramAPI\Response\Model\User $user)
     }
 }
 
-function addComment(\InstagramAPI\Response\Model\Comment $comment)
+function addComment(Comment $comment)
 {
     global $cfg_callbacks;
     logM("Comment [ID " . $comment->getMediaId() . "] @" . $comment->getUser()->getUsername() . ": " . $comment->getText());
@@ -121,7 +123,7 @@ function addComment(\InstagramAPI\Response\Model\Comment $comment)
 
 function beginListener(Instagram $ig, string $broadcastId, $streamUrl, $streamKey)
 {
-    pclose(popen("start \"Command Line Input\" ".PHP_BINARY." commandLine.php", "r"));
+    pclose(popen("start \"Command Line Input\" " . PHP_BINARY . " commandLine.php", "r"));
     cli_set_process_title("Live Chat and Like Output");
     $lastCommentTs = 0;
     $lastLikeTs = 0;
@@ -198,7 +200,7 @@ function beginListener(Instagram $ig, string $broadcastId, $streamUrl, $streamKe
                 $vCount++;
             }
             if ($vCount > 0) {
-                logM("Total Count: ".$vCount);
+                logM("Total Count: " . $vCount);
             } else {
                 logM("There are no live viewers.");
             }

--- a/goLive.php
+++ b/goLive.php
@@ -111,7 +111,7 @@ function addLike(User $user)
 function addComment(Comment $comment)
 {
     global $cfg_callbacks;
-    logM("Comment [ID " . $comment->getMediaId() . "] @" . $comment->getUser()->getUsername() . ": " . $comment->getText());
+    logM("Comment [ID " . $comment->getPk() . "] @" . $comment->getUser()->getUsername() . ": " . $comment->getText());
     if (
         $cfg_callbacks &&
         isset($cfg_callbacks['comment']) &&

--- a/goLive.php
+++ b/goLive.php
@@ -1,14 +1,15 @@
 <?php
 if (php_sapi_name() !== "cli") {
-    die("You may only run this inside of the PHP Command Line! If you did run this in the command line, please report: \"".php_sapi_name()."\" to the InstagramLive-PHP Repo!");
+    die("You may only run this inside of the PHP Command Line! If you did run this in the command line, please report: \"" . php_sapi_name() . "\" to the InstagramLive-PHP Repo!");
 }
 
-logM("Loading InstagramLive-PHP v0.4...");
+logM("Loading InstagramLive-PHP v0.5...");
 set_time_limit(0);
 date_default_timezone_set('America/New_York');
 
 //Load Depends from Composer...
-require __DIR__.'/vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
+
 use InstagramAPI\Instagram;
 use InstagramAPI\Request\Live;
 
@@ -33,7 +34,7 @@ try {
         logM("Two-Factor Required! Please check your phone for an SMS Code!");
         $twoFactorIdentifier = $loginResponse->getTwoFactorInfo()->getTwoFactorIdentifier();
         print "\nType your 2FA Code from SMS> ";
-        $handle = fopen ("php://stdin","r");
+        $handle = fopen("php://stdin", "r");
         $verificationCode = trim(fgets($handle));
         logM("Logging in with 2FA Code...");
         $ig->finishTwoFactorLogin(IG_USERNAME, IG_PASS, $twoFactorIdentifier, $verificationCode);
@@ -43,7 +44,7 @@ try {
         logM("Account Flagged: Please sign out of all phones and try logging into instagram.com from this computer before trying to run this script again!");
         exit();
     }
-    echo 'Error While Logging in to Instagram: '.$e->getMessage()."\n";
+    echo 'Error While Logging in to Instagram: ' . $e->getMessage() . "\n";
     exit(0);
 }
 
@@ -65,34 +66,163 @@ try {
     );
 
     //Grab the stream url as well as the stream key.
-    $split = preg_split("[".$broadcastId."]", $streamUploadUrl);
+    $split = preg_split("[" . $broadcastId . "]", $streamUploadUrl);
 
     $streamUrl = $split[0];
-    $streamKey = $broadcastId.$split[1];
+    $streamKey = $broadcastId . $split[1];
 
-    logM("================================ Stream URL ================================\n".$streamUrl."\n================================ Stream URL ================================");
+    logM("================================ Stream URL ================================\n" . $streamUrl . "\n================================ Stream URL ================================");
 
-    logM("======================== Current Stream Key ========================\n".$streamKey."\n======================== Current Stream Key ========================");
+    logM("======================== Current Stream Key ========================\n" . $streamKey . "\n======================== Current Stream Key ========================");
 
     logM("^^ Please Start Streaming in OBS/Streaming Program with the URL and Key Above ^^");
 
-    logM("Live Stream is Ready for Commands:");
-    newCommand($ig->live, $broadcastId, $streamUrl, $streamKey);
+    if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+        logM("You are using Windows! Therefore, your system supports the viewing of comments and likes!\nThis window will turn into the comment and like view and console output.\nA second window will open which will allow you to dispatch commands!");
+        beginListener($ig, $broadcastId, $streamUrl, $streamKey);
+    } else {
+        logM("You are not using Windows! Therefore, the script has been put into legacy mode. New commands may not be added to legacy mode but backend features will remain.\nIt is recommended that you use Windows for the full experience!");
+        logM("Live Stream is Ready for Commands:");
+        newCommand($ig->live, $broadcastId, $streamUrl, $streamKey);
+    }
+
     logM("Something Went Super Wrong! Attempting to At-Least Clean Up!");
     $ig->live->getFinalViewerList($broadcastId);
     $ig->live->end($broadcastId);
 } catch (\Exception $e) {
-    echo 'Error While Creating Livestream: '.$e->getMessage()."\n";
+    echo 'Error While Creating Livestream: ' . $e->getMessage() . "\n";
+}
+
+function addLike(\InstagramAPI\Response\Model\User $user)
+{
+    global $cfg_callbacks;
+    logM("@".$user->getUsername()." has liked the stream!");
+    if (
+        $cfg_callbacks &&
+        isset($cfg_callbacks['like']) &&
+        is_callable($cfg_callbacks['like'])
+    ) {
+        $cfg_callbacks['like']($user);
+    }
+}
+
+function addComment(\InstagramAPI\Response\Model\Comment $comment)
+{
+    global $cfg_callbacks;
+    logM("Comment [ID " . $comment->getMediaId() . "] @" . $comment->getUser()->getUsername() . ": " . $comment->getText());
+    if (
+        $cfg_callbacks &&
+        isset($cfg_callbacks['comment']) &&
+        is_callable($cfg_callbacks['comment'])
+    ) {
+        $cfg_callbacks['comment']($comment->getUser(), $comment);
+    }
+}
+
+function beginListener(Instagram $ig, string $broadcastId, $streamUrl, $streamKey)
+{
+    pclose(popen("start \"Command Line Input\" ".PHP_BINARY." commandLine.php", "r"));
+    cli_set_process_title("Live Chat and Like Output");
+    $lastCommentTs = 0;
+    $lastLikeTs = 0;
+    $exit = false;
+
+    @unlink(__DIR__ . '/request');
+
+    do {
+        $cmd = '';
+        $values = [];
+        /** @noinspection PhpComposerExtensionStubsInspection */
+        $request = json_decode(@file_get_contents(__DIR__ . '/request'), true);
+        if (!empty($request)) {
+            $cmd = $request['cmd'];
+            $values = $request['values'];
+        }
+        if ($cmd == 'ecomments') {
+            $ig->live->enableComments($broadcastId);
+            logM("Enabled Comments!");
+            unlink(__DIR__ . '/request');
+        } elseif ($cmd == 'dcomments') {
+            $ig->live->disableComments($broadcastId);
+            logM("Disabled Comments!");
+            unlink(__DIR__ . '/request');
+        } elseif ($cmd == 'end') {
+            $archived = $values[0];
+            logM("Wrapping up and exiting...");
+            //Needs this to retain, I guess?
+            $ig->live->getFinalViewerList($broadcastId);
+            $ig->live->end($broadcastId);
+            if ($archived == 'yes') {
+                $ig->live->addToPostLive($broadcastId);
+                logM("Livestream added to Archive!");
+            }
+            logM("Ended stream!");
+            unlink(__DIR__ . '/request');
+            sleep(2);
+            exit();
+        } elseif ($cmd == 'url') {
+            logM("================================ Stream URL ================================\n" . $streamUrl . "\n================================ Stream URL ================================");
+            unlink(__DIR__ . '/request');
+        } elseif ($cmd == 'key') {
+            logM("======================== Current Stream Key ========================\n" . $streamKey . "\n======================== Current Stream Key ========================");
+            unlink(__DIR__ . '/request');
+        } elseif ($cmd == 'info') {
+            $info = $ig->live->getInfo($broadcastId);
+            $status = $info->getStatus();
+            $muted = var_export($info->is_Messages(), true);
+            $count = $info->getViewerCount();
+            logM("Info:\nStatus: $status \nMuted: $muted \nViewer Count: $count");
+            unlink(__DIR__ . '/request');
+        } elseif ($cmd == 'viewers') {
+            $output = '';
+            $ig->live->getInfo($broadcastId);
+            foreach ($ig->live->getViewerList($broadcastId)->getUsers() as &$cuser) {
+                $output .= "@" . $cuser->getUsername() . " (" . $cuser->getFullName() . ")\n";
+            }
+            logM($output);
+            unlink(__DIR__ . '/request');
+        }
+        // Get broadcast comments.
+        // - The latest comment timestamp will be required for the next
+        //   getComments() request.
+        // - There are two types of comments: System comments and user comments.
+        //   We compare both and keep the newest (most recent) timestamp.
+        $commentsResponse = $ig->live->getComments($broadcastId, $lastCommentTs);
+        $systemComments = $commentsResponse->getSystemComments();
+        $comments = $commentsResponse->getComments();
+        if (!empty($systemComments)) {
+            $lastCommentTs = end($systemComments)->getCreatedAt();
+        }
+        if (!empty($comments) && end($comments)->getCreatedAt() > $lastCommentTs) {
+            $lastCommentTs = end($comments)->getCreatedAt();
+        }
+        foreach ($comments as $comment) {
+            addComment($comment);
+        }
+        // Get broadcast heartbeat and viewer count.
+        $ig->live->getHeartbeatAndViewerCount($broadcastId);
+        // Get broadcast like count.
+        // - The latest like timestamp will be required for the next
+        //   getLikeCount() request.
+        $likeCountResponse = $ig->live->getLikeCount($broadcastId, $lastLikeTs);
+        $lastLikeTs = $likeCountResponse->getLikeTs();
+        foreach ($likeCountResponse->getLikers() as $user) {
+            $user = $ig->people->getInfoById($user->getUserId())->getUser();
+            addLike($user);
+        }
+        sleep(2);
+    } while (!$exit);
 }
 
 /**
  * The handler for interpreting the commands passed via the command line.
  */
-function newCommand(Live $live, $broadcastId, $streamUrl, $streamKey) {
+function newCommand(Live $live, $broadcastId, $streamUrl, $streamKey)
+{
     print "\n> ";
-    $handle = fopen ("php://stdin","r");
+    $handle = fopen("php://stdin", "r");
     $line = trim(fgets($handle));
-    if($line == 'ecomments') {
+    if ($line == 'ecomments') {
         $live->enableComments($broadcastId);
         logM("Enabled Comments!");
     } elseif ($line == 'dcomments') {
@@ -105,7 +235,7 @@ function newCommand(Live $live, $broadcastId, $streamUrl, $streamKey) {
         $live->end($broadcastId);
         logM("Stream Ended!\nWould you like to keep the stream archived for 24 hours? Type \"yes\" to do so or anything else to not.");
         print "> ";
-        $handle = fopen ("php://stdin","r");
+        $handle = fopen("php://stdin", "r");
         $archived = trim(fgets($handle));
         if ($archived == 'yes') {
             logM("Adding to Archive!");
@@ -115,9 +245,9 @@ function newCommand(Live $live, $broadcastId, $streamUrl, $streamKey) {
         logM("Wrapping up and exiting...");
         exit();
     } elseif ($line == 'url') {
-        logM("================================ Stream URL ================================\n".$streamUrl."\n================================ Stream URL ================================");
+        logM("================================ Stream URL ================================\n" . $streamUrl . "\n================================ Stream URL ================================");
     } elseif ($line == 'key') {
-        logM("======================== Current Stream Key ========================\n".$streamKey."\n======================== Current Stream Key ========================");
+        logM("======================== Current Stream Key ========================\n" . $streamKey . "\n======================== Current Stream Key ========================");
     } elseif ($line == 'info') {
         $info = $live->getInfo($broadcastId);
         $status = $info->getStatus();
@@ -128,12 +258,12 @@ function newCommand(Live $live, $broadcastId, $streamUrl, $streamKey) {
         logM("Viewers:");
         $live->getInfo($broadcastId);
         foreach ($live->getViewerList($broadcastId)->getUsers() as &$cuser) {
-            logM("@".$cuser->getUsername()." (".$cuser->getFullName().")");
+            logM("@" . $cuser->getUsername() . " (" . $cuser->getFullName() . ")");
         }
     } elseif ($line == 'help') {
         logM("Commands:\nhelp - Prints this message\nurl - Prints Stream URL\nkey - Prints Stream Key\ninfo - Grabs Stream Info\nviewers - Grabs Stream Viewers\necomments - Enables Comments\ndcomments - Disables Comments\nstop - Stops the Live Stream");
     } else {
-       logM("Invalid Command. Type \"help\" for help!");
+        logM("Invalid Command. Type \"help\" for help!");
     }
     fclose($handle);
     newCommand($live, $broadcastId, $streamUrl, $streamKey);
@@ -142,6 +272,7 @@ function newCommand(Live $live, $broadcastId, $streamUrl, $streamKey) {
 /**
  * Logs a message in console but it actually uses new lines.
  */
-function logM($message) {
-    print $message."\n";
+function logM($message)
+{
+    print $message . "\n";
 }

--- a/goLive.php
+++ b/goLive.php
@@ -162,8 +162,14 @@ function beginListener(Instagram $ig, string $broadcastId, $streamUrl, $streamKe
                 exit();
             } elseif ($cmd == 'pin') {
                 $commentId = $values[0];
-                $ig->live->pinComment($broadcastId, $commentId);
-                logM("Pinned a comment!");
+                if (strlen($commentId) === 17 && //Comment IDs are 17 digits
+                    is_numeric($commentId) && //Comment IDs only contain numbers
+                    strpos($commentId, '-') === false) { //Comment IDs are not negitive
+                    $ig->live->pinComment($broadcastId, $commentId);
+                    logM("Pinned a comment!");
+                } else {
+                    logM("You entered an invalid comment id!");
+                }
             } elseif ($cmd == 'unpin') {
                 if ($lastCommentPin == -1) {
                     logM("You have no comment pinned!");
@@ -218,7 +224,7 @@ function beginListener(Instagram $ig, string $broadcastId, $streamUrl, $streamKe
         }
 
         if ($commentsResponse->isPinnedComment()) {
-            $pinnedComment = $commentsResponse ->getPinnedComment();
+            $pinnedComment = $commentsResponse->getPinnedComment();
             $lastCommentPin = $pinnedComment->getPk();
             $lastCommentPinHandle = $pinnedComment->getUser()->getUsername();
             $lastCommentPinText = $pinnedComment->getText();


### PR DESCRIPTION
# Windows:
The script now opens two windows. The main window/script will display output (comments/likes & general console output), while the secondary script/window will be the command line.
# Linux/macOS:
The script will now run in legacy mode on these operating systems. Legacy mode is basically what the script is as of v0.4. So there will be no comment/likes view and you will only have the commands provided to you that were in 0.4. I have no plans to backport new commands to the legacy system but I intend to keep supporting it and add any new backend changes I make.
# Download/Test This Beta:
To download & install this beta please follow these directions:

1. [Click here](https://github.com/JRoy/InstagramLive-PHP/releases/tag/0.5-BETA-3) to download the latest "Source Code (zip)". (Beta 3 as of 8/21/18)
2. Unzip this to a new folder and re-run the `composer install` command.
3. Run your goLive.php script as normal. (`php goLive.php`)
4. Please leave any bugs/feedback in this thread!

# This Pull Request:
If anyone has a Windows machine and would like to test this code please leave your feedback here.

As of now, this pull is **not** ready to merge and more changes will follow.

Thanks,
Josh