### PR TITLE
Release 0.7

### DIFF
--- a/goLive.php
+++ b/goLive.php
@@ -8,12 +8,14 @@ set_time_limit(0);
 date_default_timezone_set('America/New_York');
 
 //Argument Processing
-define("help", in_array("-h", $argv) || in_array("--help", $argv));
+define("help", in_array("-h", $argv) || in_array("-help", $argv) || in_array("--help", $argv));
 define("bypassCheck", in_array("-b", $argv) || in_array("--bypass-check", $argv));
 define("forceLegacy", in_array("-l", $argv) || in_array("--force-legacy", $argv));
+define("bypassCutoff", in_array("--bypass-cutoff", $argv));
+define("infiniteStream", in_array("-i", $argv), in_array("--infinite-stream", $argv));
 
 if (help) {
-    logM("Command Line Options:\n-h (--help): Displays this message.\n-b (--bypass-check): Bypasses the OS check. DO NOT USE THIS IF YOU DON'T KNOW WHAT YOU'RE DOING!\n-l (--force-legacy): Forces legacy mode even if you're on Windows.");
+    logM("Command Line Options:\n-h (--help): Displays this message.\n-b (--bypass-check): Bypasses the OS check. DO NOT USE THIS IF YOU DON'T KNOW WHAT YOU'RE DOING!\n-l (--force-legacy): Forces legacy mode even if you're on Windows.\n--bypass-cutoff: Bypasses hour stream cutoff. This is only suggested if you are verified!\n-i (--infinite-stream): Automatically starts the next stream when the hour cutoff is met.");
     exit();
 }
 
@@ -26,90 +28,73 @@ use InstagramAPI\Request\Live;
 use InstagramAPI\Response\Model\User;
 use InstagramAPI\Response\Model\Comment;
 
-class ExtendedInstagram extends Instagram {
-    public function changeUser( $username, $password ) {
-        $this->_setUser( $username, $password );
+class ExtendedInstagram extends Instagram
+{
+    public function changeUser($username, $password)
+    {
+        $this->_setUser($username, $password);
     }
 }
 
 require_once 'config.php';
 
-if (IG_USERNAME == "USERNAME" || IG_PASS == "PASSWORD") {
-    logM("Default Username and Passwords have not been changed! Exiting...");
-    exit();
-}
+main();
+
+function main()
+{
+    if (IG_USERNAME == "USERNAME" || IG_PASS == "PASSWORD") {
+        logM("Default Username and Passwords have not been changed! Exiting...");
+        exit();
+    }
 
 //Login to Instagram
-logM("Logging into Instagram, This can take up-to two minutes. Please wait...");
-$ig = new ExtendedInstagram(false, false);
-try {
-    $loginResponse = $ig->login(IG_USERNAME, IG_PASS);
-
-    if ($loginResponse !== null && $loginResponse->isTwoFactorRequired()) {
-        logM("Two-Factor Required! Please check your phone for an SMS Code!");
-        $twoFactorIdentifier = $loginResponse->getTwoFactorInfo()->getTwoFactorIdentifier();
-        print "\nType your 2FA Code from SMS> ";
-        $handle = fopen("php://stdin", "r");
-        $verificationCode = trim(fgets($handle));
-        logM("Logging in with 2FA Code...");
-        $ig->finishTwoFactorLogin(IG_USERNAME, IG_PASS, $twoFactorIdentifier, $verificationCode);
-    }
-} catch (\Exception $e) {
+    logM("Logging into Instagram, This can take up-to two minutes. Please wait...");
+    $ig = new ExtendedInstagram(false, false);
     try {
-        /** @noinspection PhpUndefinedMethodInspection */
-        if ($e instanceof ChallengeRequiredException && $e->getResponse()->getErrorType() === 'checkpoint_challenge_required') {
-            $response = $e->getResponse();
+        $loginResponse = $ig->login(IG_USERNAME, IG_PASS);
 
-            logM("Your account has been flagged by Instagram. InstagramLive-PHP can attempt to verify your account by a text or an email. Would you like to do that? Type \"yes\" to do so or anything else to not!");
-            logM("Note: If you already did this, and you think you entered the right code, do not attempt this again! Try logging into instagram.com from this same computer or enabling 2FA.");
-            print "> ";
+        if ($loginResponse !== null && $loginResponse->isTwoFactorRequired()) {
+            logM("Two-Factor Required! Please check your phone for an SMS Code!");
+            $twoFactorIdentifier = $loginResponse->getTwoFactorInfo()->getTwoFactorIdentifier();
+            print "\nType your 2FA Code from SMS> ";
             $handle = fopen("php://stdin", "r");
-            $attemptBypass = trim(fgets($handle));
-            if ($attemptBypass == 'yes') {
-                logM("Please wait while we prepare to verify your account.");
-                sleep(3);
+            $verificationCode = trim(fgets($handle));
+            logM("Logging in with 2FA Code...");
+            $ig->finishTwoFactorLogin(IG_USERNAME, IG_PASS, $twoFactorIdentifier, $verificationCode);
+        }
+    } catch (\Exception $e) {
+        try {
+            /** @noinspection PhpUndefinedMethodInspection */
+            if ($e instanceof ChallengeRequiredException && $e->getResponse()->getErrorType() === 'checkpoint_challenge_required') {
+                $response = $e->getResponse();
 
-                logM("Type \"sms\" for text verification or \"email\" for email verification.\nNote: If you do not have a phone number or an email address linked to your account, don't use that method ;) You can also just press enter to abort.");
+                logM("Your account has been flagged by Instagram. InstagramLive-PHP can attempt to verify your account by a text or an email. Would you like to do that? Type \"yes\" to do so or anything else to not!");
+                logM("Note: If you already did this, and you think you entered the right code, do not attempt this again! Try logging into instagram.com from this same computer or enabling 2FA.");
                 print "> ";
                 $handle = fopen("php://stdin", "r");
-                $choice = trim(fgets($handle));
-                if ($choice === "sms") {
-                    $verification_method = 0;
-                } elseif ($choice === "email") {
-                    $verification_method = 1;
-                } else {
-                    logM("You have selected an invalid verification type. Aborting!");
-                    exit();
-                }
+                $attemptBypass = trim(fgets($handle));
+                if ($attemptBypass == 'yes') {
+                    logM("Please wait while we prepare to verify your account.");
+                    sleep(3);
 
-                /** @noinspection PhpUndefinedMethodInspection */
-                $checkApiPath = substr($response->getChallenge()->getApiPath(), 1);
-                $customResponse = $ig->request($checkApiPath)
-                    ->setNeedsAuth(false)
-                    ->addPost('choice', $verification_method)
-                    ->addPost('_uuid', $ig->uuid)
-                    ->addPost('guid', $ig->uuid)
-                    ->addPost('device_id', $ig->device_id)
-                    ->addPost('_uid', $ig->account_id)
-                    ->addPost('_csrftoken', $ig->client->getToken())
-                    ->getDecodedResponse();
-
-                try {
-                    if ($customResponse['status'] === 'ok' && isset($customResponse['action'])) {
-                        if ($customResponse['action'] === 'close') {
-                            logM("Challenge Bypassed! Run the script again.");
-                            exit();
-                        }
-                    }
-
-                    logM("Please enter the code you received via " . ($verification_method ? 'email' : 'sms') . "!");
+                    logM("Type \"sms\" for text verification or \"email\" for email verification.\nNote: If you do not have a phone number or an email address linked to your account, don't use that method ;) You can also just press enter to abort.");
                     print "> ";
                     $handle = fopen("php://stdin", "r");
-                    $cCode = trim(fgets($handle));
-                    $ig->changeUser(IG_USERNAME, IG_PASS);
+                    $choice = trim(fgets($handle));
+                    if ($choice === "sms") {
+                        $verification_method = 0;
+                    } elseif ($choice === "email") {
+                        $verification_method = 1;
+                    } else {
+                        logM("You have selected an invalid verification type. Aborting!");
+                        exit();
+                    }
+
+                    /** @noinspection PhpUndefinedMethodInspection */
+                    $checkApiPath = substr($response->getChallenge()->getApiPath(), 1);
                     $customResponse = $ig->request($checkApiPath)
                         ->setNeedsAuth(false)
-                        ->addPost('security_code', $cCode)
+                        ->addPost('choice', $verification_method)
                         ->addPost('_uuid', $ig->uuid)
                         ->addPost('guid', $ig->uuid)
                         ->addPost('device_id', $ig->device_id)
@@ -117,74 +102,98 @@ try {
                         ->addPost('_csrftoken', $ig->client->getToken())
                         ->getDecodedResponse();
 
-                    logM("Provided you entered the correct code, your login attempt has probably been successful. Please try re-running the script!");
+                    try {
+                        if ($customResponse['status'] === 'ok' && isset($customResponse['action'])) {
+                            if ($customResponse['action'] === 'close') {
+                                logM("Challenge Bypassed! Run the script again.");
+                                exit();
+                            }
+                        }
+
+                        logM("Please enter the code you received via " . ($verification_method ? 'email' : 'sms') . "!");
+                        print "> ";
+                        $handle = fopen("php://stdin", "r");
+                        $cCode = trim(fgets($handle));
+                        $ig->changeUser(IG_USERNAME, IG_PASS);
+                        $customResponse = $ig->request($checkApiPath)
+                            ->setNeedsAuth(false)
+                            ->addPost('security_code', $cCode)
+                            ->addPost('_uuid', $ig->uuid)
+                            ->addPost('guid', $ig->uuid)
+                            ->addPost('device_id', $ig->device_id)
+                            ->addPost('_uid', $ig->account_id)
+                            ->addPost('_csrftoken', $ig->client->getToken())
+                            ->getDecodedResponse();
+
+                        logM("Provided you entered the correct code, your login attempt has probably been successful. Please try re-running the script!");
+                        exit();
+                    } catch (Exception $ex) {
+                        echo $ex->getMessage();
+                        exit;
+                    }
+                } else {
+                    logM("Account Flagged: Please try logging into instagram.com from this exact computer before trying to run this script again!");
                     exit();
-                } catch (Exception $ex) {
-                    echo $ex->getMessage();
-                    exit;
                 }
-            } else {
-                logM("Account Flagged: Please try logging into instagram.com from this exact computer before trying to run this script again!");
-                exit();
             }
+        } catch (\LazyJsonMapper\Exception\LazyJsonMapperException $mapperException) {
+            echo 'Error While Logging in to Instagram: ' . $e->getMessage() . "\n";
+            exit();
         }
-    } catch (\LazyJsonMapper\Exception\LazyJsonMapperException $mapperException) {
+
         echo 'Error While Logging in to Instagram: ' . $e->getMessage() . "\n";
         exit();
     }
 
-    echo 'Error While Logging in to Instagram: ' . $e->getMessage() . "\n";
-    exit();
-}
-
 //Block Responsible for Creating the Livestream.
-try {
-    if (!$ig->isMaybeLoggedIn) {
-        logM("Couldn't Login! Exiting!");
-        exit();
+    try {
+        if (!$ig->isMaybeLoggedIn) {
+            logM("Couldn't Login! Exiting!");
+            exit();
+        }
+        logM("Logged In! Creating Livestream...");
+        $stream = $ig->live->create();
+        $broadcastId = $stream->getBroadcastId();
+
+        // Switch from RTMPS to RTMP upload URL, since RTMPS doesn't work well.
+        $streamUploadUrl = preg_replace(
+            '#^rtmps://([^/]+?):443/#ui',
+            'rtmp://\1:80/',
+            $stream->getUploadUrl()
+        );
+
+        //Grab the stream url as well as the stream key.
+        $split = preg_split("[" . $broadcastId . "]", $streamUploadUrl);
+
+        $streamUrl = $split[0];
+        $streamKey = $broadcastId . $split[1];
+
+        logM("================================ Stream URL ================================\n" . $streamUrl . "\n================================ Stream URL ================================");
+
+        logM("======================== Current Stream Key ========================\n" . $streamKey . "\n======================== Current Stream Key ========================\n");
+
+        logM("Please start streaming to the url and key above! When you start streaming in your streaming application, please press enter!");
+        $pauseH = fopen("php://stdin", "r");
+        $pauseR = fgets($pauseH);
+        fclose($pauseH);
+
+        $ig->live->start($broadcastId);
+
+        if ((strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' || bypassCheck) && !forceLegacy) {
+            logM("You are using Windows! Therefore, your system supports the viewing of comments and likes!\nThis window will turn into the comment and like view and console output.\nA second window will open which will allow you to dispatch commands!");
+            beginListener($ig, $broadcastId, $streamUrl, $streamKey);
+        } else {
+            logM("You are not using Windows! Therefore, the script has been put into legacy mode. New commands may not be added to legacy mode but backend features will remain updated.\nIt is recommended that you use Windows for the full experience!");
+            logM("Live Stream is Ready for Commands:");
+            newCommand($ig->live, $broadcastId, $streamUrl, $streamKey);
+        }
+
+        logM("Something Went Super Wrong! Attempting to At-Least Clean Up!");
+        $ig->live->getFinalViewerList($broadcastId);
+        $ig->live->end($broadcastId);
+    } catch (\Exception $e) {
+        echo 'Error While Creating Livestream: ' . $e->getMessage() . "\n";
     }
-    logM("Logged In! Creating Livestream...");
-    $stream = $ig->live->create();
-    $broadcastId = $stream->getBroadcastId();
-
-    $streamUploadUrl = preg_replace(
-        '#^rtmps://([^/]+?):443/#ui',
-        'rtmp://\1:80/',
-        $stream->getUploadUrl()
-    );
-
-    //Grab the stream url as well as the stream key.
-    $split = preg_split("[" . $broadcastId . "]", $streamUploadUrl);
-
-    $streamUrl = $split[0];
-    $streamKey = $broadcastId . $split[1];
-
-    logM("================================ Stream URL ================================\n" . $streamUrl . "\n================================ Stream URL ================================");
-
-    logM("======================== Current Stream Key ========================\n" . $streamKey . "\n======================== Current Stream Key ========================\n");
-
-    logM("Please start streaming to the url and key above! When you start streaming in your streaming application, please press enter!");
-    $pauseH = fopen("php://stdin", "r");
-    $pauseR = fgets($pauseH);
-    fclose($pauseH);
-
-    $ig->live->start($broadcastId);
-    // Switch from RTMPS to RTMP upload URL, since RTMPS doesn't work well.
-
-    if ((strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' || bypassCheck) && !forceLegacy) {
-        logM("You are using Windows! Therefore, your system supports the viewing of comments and likes!\nThis window will turn into the comment and like view and console output.\nA second window will open which will allow you to dispatch commands!");
-        beginListener($ig, $broadcastId, $streamUrl, $streamKey);
-    } else {
-        logM("You are not using Windows! Therefore, the script has been put into legacy mode. New commands may not be added to legacy mode but backend features will remain updated.\nIt is recommended that you use Windows for the full experience!");
-        logM("Live Stream is Ready for Commands:");
-        newCommand($ig->live, $broadcastId, $streamUrl, $streamKey);
-    }
-
-    logM("Something Went Super Wrong! Attempting to At-Least Clean Up!");
-    $ig->live->getFinalViewerList($broadcastId);
-    $ig->live->end($broadcastId);
-} catch (\Exception $e) {
-    echo 'Error While Creating Livestream: ' . $e->getMessage() . "\n";
 }
 
 function addLike(User $user)
@@ -213,11 +222,15 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey)
     $lastCommentPinHandle = '';
     $lastCommentPinText = '';
     $exit = false;
+    $startTime = time();
+
 
     @unlink(__DIR__ . '/request');
 
     do {
         /** @noinspection PhpComposerExtensionStubsInspection */
+
+        //Check for commands
         $request = json_decode(@file_get_contents(__DIR__ . '/request'), true);
         if (!empty($request)) {
             $cmd = $request['cmd'];
@@ -300,6 +313,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey)
             unlink(__DIR__ . '/request');
         }
 
+        //Process Comments
         $commentsResponse = $ig->live->getComments($broadcastId, $lastCommentTs); //Request comments since the last time we checked
         $systemComments = $commentsResponse->getSystemComments(); //No idea what system comments are, but we need to so we can track comments
         $comments = $commentsResponse->getComments(); //Get the actual comments from the request we made
@@ -325,6 +339,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey)
             }
         }
 
+        //Process Likes
         $ig->live->getHeartbeatAndViewerCount($broadcastId); //Maintain :clap: comments :clap: and :clap: likes :clap: after :clap: stream
         $likeCountResponse = $ig->live->getLikeCount($broadcastId, $lastLikeTs); //Get our current batch for likes
         $lastLikeTs = $likeCountResponse->getLikeTs();
@@ -332,6 +347,32 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey)
             $user = $ig->people->getInfoById($user->getUserId())->getUser();
             addLike($user);
         }
+
+        //Calculate Times
+        if (!bypassCutoff && (time() - $startTime) >= 3480) {
+            logM("Your stream has ended due to Instagram's one hour time limit! Would you like to archive this stream?");
+            print "> ";
+            $handle = fopen("php://stdin", "r");
+            $archived = trim(fgets($handle));
+            if ($archived == 'yes') {
+                logM("Adding to Archive...");
+                $ig->live->addToPostLive($broadcastId);
+                logM("Livestream added to archive!");
+            }
+            logM("Would you like to go live again?");
+            print "> ";
+            $handle = fopen("php://stdin", "r");
+            $restart = trim(fgets($handle));
+            if ($restart == 'yes' || infiniteStream) {
+                logM("Restarting Livestream!");
+                main();
+            }
+            logM("Stream Ended! Please remember to close the console window!");
+            unlink(__DIR__ . '/request');
+            sleep(2);
+            exit();
+        }
+
         sleep(2);
     } while (!$exit);
 }

--- a/goLive.php
+++ b/goLive.php
@@ -38,9 +38,9 @@ class ExtendedInstagram extends Instagram
 
 require_once 'config.php';
 
-main();
+main(true);
 
-function main()
+function main($console)
 {
     if (IG_USERNAME == "USERNAME" || IG_PASS == "PASSWORD") {
         logM("Default Username and Passwords have not been changed! Exiting...");
@@ -181,7 +181,7 @@ function main()
 
         if ((strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' || bypassCheck) && !forceLegacy) {
             logM("You are using Windows! Therefore, your system supports the viewing of comments and likes!\nThis window will turn into the comment and like view and console output.\nA second window will open which will allow you to dispatch commands!");
-            beginListener($ig, $broadcastId, $streamUrl, $streamKey);
+            beginListener($ig, $broadcastId, $streamUrl, $streamKey, $console);
         } else {
             logM("You are not using Windows! Therefore, the script has been put into legacy mode. New commands may not be added to legacy mode but backend features will remain updated.\nIt is recommended that you use Windows for the full experience!");
             logM("Live Stream is Ready for Commands:");
@@ -206,14 +206,16 @@ function addComment(Comment $comment)
     logM("Comment [ID " . $comment->getPk() . "] @" . $comment->getUser()->getUsername() . ": " . $comment->getText());
 }
 
-function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey)
+function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $console)
 {
     if (bypassCheck) {
         logM("You are bypassing the operating system check in an attempt to run the async command line on non-windows devices. THIS IS EXTREMELY UNSUPPORTED AND I DON'T RECOMMEND IT!");
         logM("That being said, if you cannot start the command line and *need* to end the stream just start the script again without bypassing the check and run the stop command.");
         logM("You must start commandLine.php manually.");
     } else {
-        pclose(popen("start \"Command Line Input\" php commandLine.php", "r"));
+        if ($console) {
+            pclose(popen("start \"Command Line Input\" php commandLine.php", "r"));
+        }
     }
     cli_set_process_title("Live Chat and Like Output");
     $lastCommentTs = 0;
@@ -365,7 +367,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey)
             $restart = trim(fgets($handle));
             if ($restart == 'yes' || infiniteStream) {
                 logM("Restarting Livestream!");
-                main();
+                main(false);
             }
             logM("Stream Ended! Please remember to close the console window!");
             unlink(__DIR__ . '/request');


### PR DESCRIPTION
# About Release
This release adds Instagram one-hour stream cutoff handling and organizes the code so it doesn't look like complete garbage that just so happens to "work".

# Changelog
* Properly handle the one-hour live stream limit.
* Add -i (--infinite-stream) command line option to automatically start a new live stream when the one-hour limit is reached.
* Add error dumping.
* Add -d (--dump) to trigger an error dump without an error

# Download Beta
To download & install this beta please follow these directions:

1. [Click here](https://github.com/JRoy/InstagramLive-PHP/releases/tag/0.7-BETA-2) to download the latest "Source Code (zip)". (Beta 2 as of 11/11/18)
2. Unzip this to a new folder and re-run the `composer install` command.
3. Run your goLive.php script as normal. (`php goLive.php`)
4. Please leave any bugs/feedback in this thread!

# Feedback
If you do decide to test this release, please leave any and all feedback/bug reports in this thread.