### PR TITLE
Release/1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ If your system does not support OBS integration or you want to see what settings
 To view comments and likes as you are streaming, you'll need a Windows machine as this script's async support only works on Windows. When you run the script on Windows, after it logs you in, it will open a second screen where you can enter commands as the first screen will output comments and likes.
 
 Linux/Mac support is planned for a future release.
-# Commands
-InstagramLive-PHP has a plenty of commands to aid in live streaming. To view them, along with which commands work on what operating system, [visit the wiki by clicking here](https://github.com/JRoy/InstagramLive-PHP/wiki/Commands) to view the table of commands and their descriptions. 
+# Commands & Command Line Arguments
+InstagramLive-PHP has many commands to aid while streaming as well as command line arguments to change the behavior of the script. To view what they are and which ones work on what operating system: [click here for the streaming commands](https://github.com/JRoy/InstagramLive-PHP/wiki/Commands) or [click here for the command line arguments](https://github.com/JRoy/InstagramLive-PHP/wiki/Command-Line-Arguments). 
 # FAQ
 #### OBS gives a "Failed to connect" error
 This is mostly due to an invalid stream key: The stream key changes **every** time you start a new stream so it must be replaced in OBS every time.

--- a/goLive.php
+++ b/goLive.php
@@ -25,6 +25,7 @@ $helpData = registerArgument($helpData, $argv, "obsAutomationAccept", "Automatic
 $helpData = registerArgument($helpData, $argv, "obsNoStream", "Disables automatic stream start in OBS.", "-obs-no-stream");
 $helpData = registerArgument($helpData, $argv, "disableObsAutomation", "Disables OBS automation and subsequently disables the path check.", "-no-obs");
 $helpData = registerArgument($helpData, $argv, "startDisableComments", "Automatically disables commands when the stream starts.", "-dcomments");
+$helpData = registerArgument($helpData, $argv, "useRmtps", "Uses rmtps rather than rmtp for clients that refuse rmtp.", "-use-rmtps");
 $helpData = registerArgument($helpData, $argv, "dump", "Forces an error dump for debug purposes.", "d", "dump");
 $helpData = registerArgument($helpData, $argv, "dumpFlavor", "Dumps", "-dumpFlavor");
 
@@ -213,11 +214,11 @@ function main($console, ObsHelper $helper)
         $broadcastId = $stream->getBroadcastId();
 
         // Switch from RTMPS to RTMP upload URL, since RTMPS doesn't work well.
-        $streamUploadUrl = preg_replace(
+        $streamUploadUrl = (!useRmtps === true ? preg_replace(
             '#^rtmps://([^/]+?):443/#ui',
             'rtmp://\1:80/',
             $stream->getUploadUrl()
-        );
+        ) : $stream->getUploadUrl());
 
         //Grab the stream url as well as the stream key.
         $split = preg_split("[" . $broadcastId . "]", $streamUploadUrl);

--- a/goLive.php
+++ b/goLive.php
@@ -172,7 +172,7 @@ function main($console, ObsHelper $helper)
                             ->addPost('_csrftoken', $ig->client->getToken())
                             ->getDecodedResponse();
 
-                        if ($customResponse['status'] === 'ok' && $customResponse['logged_in_user']['pk'] !== null) {
+                        if (@$customResponse['status'] === 'ok' && @$customResponse['logged_in_user']['pk'] !== null) {
                             Utils::log("Suspicious Login: Account challenge successful, please re-run the script!");
                             exit();
                         } else {

--- a/goLive.php
+++ b/goLive.php
@@ -23,6 +23,7 @@ $helpData = registerArgument($helpData, $argv, "autoArchive", "Automatically arc
 $helpData = registerArgument($helpData, $argv, "logCommentOutput", "Logs comment and like output into a text file.", "o", "comment-output");
 $helpData = registerArgument($helpData, $argv, "obsAutomationAccept", "Automatically accepts the OBS prompt.", "-obs");
 $helpData = registerArgument($helpData, $argv, "obsNoStream", "Disables automatic stream start in OBS.", "-obs-no-stream");
+$helpData = registerArgument($helpData, $argv, "disableObsAutomation", "Disables OBS automation and subsequently disables the path check.", "-no-obs");
 $helpData = registerArgument($helpData, $argv, "startDisableComments", "Automatically disables commands when the stream starts.", "-dcomments");
 $helpData = registerArgument($helpData, $argv, "dump", "Forces an error dump for debug purposes.", "d", "dump");
 $helpData = registerArgument($helpData, $argv, "dumpFlavor", "Dumps", "-dumpFlavor");
@@ -84,7 +85,7 @@ class ExtendedInstagram extends Instagram
 require_once 'config.php';
 
 //Run the script and spawn a new console window if applicable.
-main(true, new ObsHelper(!obsNoStream));
+main(true, new ObsHelper(!obsNoStream, disableObsAutomation));
 
 function main($console, ObsHelper $helper)
 {

--- a/goLive.php
+++ b/goLive.php
@@ -34,7 +34,7 @@ require 'utils.php';
 
 define("scriptVersion", "1.1");
 define("scriptVersionCode", "27");
-define("scriptFlavor", "custom");
+define("scriptFlavor", "stable");
 Utils::log("Loading InstagramLive-PHP v" . scriptVersion . "...");
 
 if (Utils::checkForUpdate(scriptVersionCode, scriptFlavor)) {

--- a/goLive.php
+++ b/goLive.php
@@ -22,6 +22,7 @@ $helpData = registerArgument($helpData, $argv, "infiniteStream", "Automatically 
 $helpData = registerArgument($helpData, $argv, "autoArchive", "Automatically archives a live stream after it ends.", "a", "auto-archive");
 $helpData = registerArgument($helpData, $argv, "logCommentOutput", "Logs comment and like output into a text file.", "o", "comment-output");
 $helpData = registerArgument($helpData, $argv, "obsAutomationAccept", "Automatically accepts the OBS prompt.", "-obs");
+$helpData = registerArgument($helpData, $argv, "obsNoStream", "Disables automatic stream start in OBS.", "-obs-no-stream");
 $helpData = registerArgument($helpData, $argv, "startDisableComments", "Automatically disables commands when the stream starts.", "-dcomments");
 $helpData = registerArgument($helpData, $argv, "dump", "Forces an error dump for debug purposes.", "d", "dump");
 $helpData = registerArgument($helpData, $argv, "dumpFlavor", "Dumps", "-dumpFlavor");
@@ -29,9 +30,9 @@ $helpData = registerArgument($helpData, $argv, "dumpFlavor", "Dumps", "-dumpFlav
 //Load Utils
 require 'utils.php';
 
-define("scriptVersion", "1.0");
-define("scriptVersionCode", "26");
-define("scriptFlavor", "stable");
+define("scriptVersion", "1.1");
+define("scriptVersionCode", "27");
+define("scriptFlavor", "custom");
 Utils::log("Loading InstagramLive-PHP v" . scriptVersion . "...");
 
 if (Utils::checkForUpdate(scriptVersionCode, scriptFlavor)) {
@@ -83,7 +84,7 @@ class ExtendedInstagram extends Instagram
 require_once 'config.php';
 
 //Run the script and spawn a new console window if applicable.
-main(true, new ObsHelper());
+main(true, new ObsHelper(!obsNoStream));
 
 function main($console, ObsHelper $helper)
 {
@@ -280,7 +281,7 @@ function main($console, ObsHelper $helper)
             }
         }
 
-        if (!$obsAutomation) {
+        if (!$obsAutomation || obsNoStream) {
             Utils::log("Please start streaming to the url and key above! Once you are live, please press enter!");
             $pauseH = fopen("php://stdin", "r");
             fgets($pauseH);

--- a/obs.php
+++ b/obs.php
@@ -1,5 +1,7 @@
 <?php /** @noinspection PhpComposerExtensionStubsInspection */
 
+require_once 'utils.php';
+
 class ObsHelper
 {
     public $obs_path;
@@ -25,14 +27,20 @@ class ObsHelper
         $this->attempted_settings_save = false;
         $this->autoStream = $autoStream;
 
+        if (!Utils::isWindows()) {
+            $this->obs_path = null;
+            return;
+        }
+
         clearstatcache();
         if (@file_exists("C:/Program Files/obs-studio/")) {
             $this->obs_path = "C:/Program Files/obs-studio/";
+            return;
         } elseif (@file_exists("C:/Program Files (x86)/obs-studio/")) {
             $this->obs_path = "C:/Program Files (x86)/obs-studio/";
-        } else {
-            $this->obs_path = null; //OBS's path could not be found, the script will disable OBS integration.
+            return;
         }
+        $this->obs_path = null; //OBS's path could not be found, the script will disable OBS integration.
     }
 
     /**

--- a/obs.php
+++ b/obs.php
@@ -9,11 +9,13 @@ class ObsHelper
     public $settings_state;
     public $attempted_service_save;
     public $attempted_settings_save;
+    public $autoStream;
 
     /**
      * Checks for OBS installation and detects service file locations.
+     * @param bool $autoStream Automatically starts streaming in OBS if true.
      */
-    public function __construct()
+    public function __construct(bool $autoStream)
     {
         $this->service_path = getenv("appdata") . "\obs-studio\basic\profiles\Untitled\service.json";
         $this->settings_path = getenv("appdata") . "\obs-studio\basic\profiles\Untitled\basic.ini";
@@ -21,6 +23,7 @@ class ObsHelper
         $this->settings_state = null;
         $this->attempted_service_save = false;
         $this->attempted_settings_save = false;
+        $this->autoStream = $autoStream;
 
         clearstatcache();
         if (@file_exists("C:/Program Files/obs-studio/")) {
@@ -127,7 +130,7 @@ class ObsHelper
     public function spawnOBS()
     {
         clearstatcache();
-        pclose(popen("cd \"$this->obs_path" . "bin/64bit\" && start /B obs64.exe --startstreaming", "r"));
+        pclose(popen("cd \"$this->obs_path" . "bin/64bit\" && start /B obs64.exe" . ($this->autoStream ? " --startstreaming" : ""), "r"));
         return true;
     }
 

--- a/obs.php
+++ b/obs.php
@@ -16,8 +16,9 @@ class ObsHelper
     /**
      * Checks for OBS installation and detects service file locations.
      * @param bool $autoStream Automatically starts streaming in OBS if true.
+     * @param bool $disable Disables path check if true.
      */
-    public function __construct(bool $autoStream)
+    public function __construct(bool $autoStream, bool $disable)
     {
         $this->service_path = getenv("appdata") . "\obs-studio\basic\profiles\Untitled\service.json";
         $this->settings_path = getenv("appdata") . "\obs-studio\basic\profiles\Untitled\basic.ini";
@@ -27,7 +28,7 @@ class ObsHelper
         $this->attempted_settings_save = false;
         $this->autoStream = $autoStream;
 
-        if (!Utils::isWindows()) {
+        if (!Utils::isWindows() || $disable) {
             $this->obs_path = null;
             return;
         }

--- a/update.php
+++ b/update.php
@@ -34,7 +34,7 @@ foreach ($release['files'] as $file) {
 logTxt("Checking for config updates...");
 if (file_exists("config.php")) {
     include_once 'config.php';
-    if ((int) configVersionCode < (int) $release['config']['versionCode']) {
+    if ((int)configVersionCode < (int)$release['config']['versionCode']) {
         logTxt("Outdated config version code, updating...");
         file_put_contents("config.php", file_get_contents($release['config']['url']));
         logTxt("Updated config, you'll need to re-populate your config username and password.");
@@ -61,7 +61,7 @@ logTxt("Files Updated!");
 
 if ($composer) {
     logTxt("Detected composer update, re-installing");
-    exec("composer update");
+    exec((file_exists("composer.phar") ? "composer.phar" : "composer") . " update");
 }
 logTxt("InstagramLive-PHP is now up-to-date!");
 


### PR DESCRIPTION
# Changelog:
* Added 3 more command line arguments
  * --obs-no-stream for disabling auto streaming in OBS
  * --no-obs to disable OBS path check (and automation)
  * --use-rmtps to favor rmtps over rmtp for stubborn clients
* Improved ObsHelper Performance on Mac/Linux
* Fix a bug where the updater would not always detect composer
* Fix a bug where php would spit "useless" errors sometimes (#76)