### PR TITLE
Release 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Built with [mgp25's amazing Instagram Private API Wrapper for PHP](https://githu
 # Note
 Please read this **entire** document as it has *very* important information about the script. If you create an issue that can be solved by reading this document, it will be ignored.
 
-# Setup
+# Live Setup
 It is suggested you watch [this video](https://www.youtube.com/watch?v=J6lp8g3zQeE) for a step-by-step process on how to install this script.
 
 1. Install PHP, of course...
@@ -17,39 +17,40 @@ It is suggested you watch [this video](https://www.youtube.com/watch?v=J6lp8g3zQ
 7. Run the `goLive.php` script. (`php goLive.php`)
 #### Video Tutorial
 If you'd like a video version of this tutorial, see [this video](https://www.youtube.com/watch?v=J6lp8g3zQeE).
-# OBS-Setup
-If your system does not support OBS integration or you want to see what settings to use for another streaming program, look here.
-1. Set your OBS canvas size to 720x1280. This can be done by going to Settings->Video and editing Base Canvas Resolution to "720x1280".
-2. Go to the "Stream" section of your OBS Settings 
-3. Set "Stream Type" to "Custom Streaming Server"
-4. Set the "URL" field to the stream url you got from the script
-5. Set the "Stream key" field to the stream key you got from the script
-6. Make Sure "Use Authentication" is **unchecked** and press "OK"
-7. Start Streaming in OBS
-8. To stop streaming, run the "stop" command in your terminal and then press "Stop Streaming" in OBS
-# Comment & Like Viewing
-To view comments and likes as you are streaming, you'll need a Windows machine as this script's async support only works on Windows. When you run the script on Windows, after it logs you in, it will open a second screen where you can enter commands as the first screen will output comments and likes.
+# Features
+* Robust Installer/Updater
+  * To install read the [Live Setup](#live-setup) section
+  * To check for/apply an update just do `php update.php`
+    * If you want to try beta feature just do: `php update.php --beta`
+* Supports Accounts with 2FA
+* View Live Chat/Likes (Windows/Mac Only)
+* Execute Commands to Comment, Wave, Pin Comments, Show Questions, and more...
+* Launch & Start OBS Automatically (Windows Only)
+* Infinite Stream: Stream forever with no user input! (Windows/Mac Only)
+  * Accomplished by doing: `php goLive.php -i -d`
+  * Windows Users with OBS can do `php goLive.php -i -d --obs` for absolutely no input from the user required
+* Archived Stream Statistics
+  * Accomplished by doing: `php checkVod.php` 24 hours within archiving a stream
+# Commands
+To view what commands you can run while streaming: [Click Here](https://github.com/JRoy/InstagramLive-PHP/wiki/Commands)
 
-Linux/Mac support is planned for a future release.
-# Previous Livestream Statistics
-In addition to letting you go live, InstagramLive-PHP also has a script to display statistics from your archived livestreams. Just run `php checkVod.php` to view a list of your currently archived livestreams and view available statistics about them.
-# Commands & Command Line Arguments
-InstagramLive-PHP has many commands to aid while streaming as well as command line arguments to change the behavior of the script. To view what they are and which ones work on what operating system: [click here for the streaming commands](https://github.com/JRoy/InstagramLive-PHP/wiki/Commands) or [click here for the command line arguments](https://github.com/JRoy/InstagramLive-PHP/wiki/Command-Line-Arguments). 
+To view what flags you can run the `goLive.php` script with: [Click Here](https://github.com/JRoy/InstagramLive-PHP/wiki/Command-Line-Arguments) 
 # FAQ
 #### OBS gives a "Failed to connect" error
-This is mostly due to an invalid stream key: The stream key changes **every** time you start a new stream so it must be replaced in OBS every time.
+This could be due to the following reasons:
+* An invalid stream key. The stream key changes for every stream, make sure you update it.
+* Your system does not support un-secure rmtp. You can fix this by running the script with `--use-rmtps` (`php goLive.php --use-rmtps`).
 #### I've stopped streaming but Instagram still shows me as live
-This is due to you not running the "stop" command inside the script. You cannot just close the command window to make Instagram stop streaming, you must run the stop command in the script. If you *do* close the command window however, start it again and just run the stop command, this should stop Instagram from listing to live content.
-#### I get an error inside of Instagram when archiving my story
-This is usually due to archiving a stream that had no content (video). Just delete the archive and be go on with your day.
-#### I archived my live stream but I don't see it inside of Instagram
-This is can be caused by 1 of 2 reasons:
-* You did not stream anything. Please make sure you actually send a video to the stream url or the archive may fail to load.
-* You did not change your stream content/canvas size. If you are using OBS, you can address this by following step one in [OBS Setup Section](https://github.com/JRoy/InstagramLive-PHP#obs-setup).
+Make sure you actually running the `stop` command when you're streaming and not close it.
+#### I don't see or get an error in Instagram when archiving my story
+This could be due to the following reasons:
+* You didn't stream anything from OBS/your encoder. In this case, you should delete the archive.
+* You streamed a disallowed aspect ratio. Make sure you're using a vertical 16:9 aspect ratio (9:16) like 720x1280. In this case, you should delete the archive.
+* Your stream is still processing. This is normal for longer streams.
 #### I get "CURL Error 60: SSL certificate problem" when trying to log into Instagram
 This is due to CURL not having a valid CA. You can find a solution here: [https://stackoverflow.com/a/34883260](https://stackoverflow.com/a/34883260).
 #### I get "CURL Error 28: Operation timed out after x milliseconds with 0 bytes received."
-This means Instagram is refusing to connect to your proxy/computer. This could be for a wide verity of different reasons. I cannot help you when this if this happens, it's out of my control and there is nothing you can do to fix this other than changing your IP Address or actual computer you are using. Additionally, a proxy or VPN could create this issue.
+In this case, your IP is blocked by Instagram. There is nothing I can do in this situation, if you're using a VPN/Proxy (which are not supported), don't. 
 ### Question not listed here?
 If your question is not listed here, [join our discord](https://discord.gg/EpkKFt3) so I can help support you faster. [https://discord.gg/EpkKFt3](https://discord.gg/EpkKFt3)
 # Donate

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ If your system does not support OBS integration or you want to see what settings
 To view comments and likes as you are streaming, you'll need a Windows machine as this script's async support only works on Windows. When you run the script on Windows, after it logs you in, it will open a second screen where you can enter commands as the first screen will output comments and likes.
 
 Linux/Mac support is planned for a future release.
+# Previous Livestream Statistics
+In addition to letting you go live, InstagramLive-PHP also has a script to display statistics from your archived livestreams. Just run `php checkVod.php` to view a list of your currently archived livestreams and view available statistics about them.
 # Commands & Command Line Arguments
 InstagramLive-PHP has many commands to aid while streaming as well as command line arguments to change the behavior of the script. To view what they are and which ones work on what operating system: [click here for the streaming commands](https://github.com/JRoy/InstagramLive-PHP/wiki/Commands) or [click here for the command line arguments](https://github.com/JRoy/InstagramLive-PHP/wiki/Command-Line-Arguments). 
 # FAQ

--- a/checkVod.php
+++ b/checkVod.php
@@ -19,14 +19,18 @@ $helpData = registerArgument($helpData, $argv, "help", "Displays this message.",
 $helpData = registerArgument($helpData, $argv, "promptLogin", "Ignores config.php and prompts you for your username and password.", "p", "prompt-login");
 $helpData = registerArgument($helpData, $argv, "autoSelect", "Automatically selects the first vod that the script finds.", "a", "auto-select");
 $helpData = registerArgument($helpData, $argv, "thisIsPlaceHolder", "Sets the broadcast id to grab data from. (Example: --broadcast-id=17854587811139572).", "-broadcast-id");
+$helpData = registerArgument($helpData, $argv, "placeHolder", "Sets the file to output data to. (Example: --output=info.txt).", "-output");
 $helpData = registerArgument($helpData, $argv, "autoDelete", "Automatically deletes the selected live stream.", "d", "delete");
 $helpData = registerArgument($helpData, $argv, "autoInfo", "Automatically prints info about the selected live stream.", "i", "info");
 
 $preSelectedBroadcast = "0";
+$outputFile = '';
 
 foreach ($argv as $curArg) {
     if (strpos($curArg, '--broadcast-id=') !== false) {
         $preSelectedBroadcast = (string)str_replace('--broadcast-id=', '', $curArg);
+    } elseif (strpos($curArg, '--output=') !== false) {
+        $outputFile = (string)str_replace('--output=', '', $curArg);
     }
 }
 
@@ -93,7 +97,7 @@ if (!autoSelect && $preSelectedBroadcast === '0') {
 
 if ($preSelectedBroadcast !== '0') {
     if (!isset($postLiveCache[$preSelectedBroadcast])) {
-        Utils::log("Invalid Livestream ID! Exiting...");
+        Utils::log("Invalid Livestream ID! Exiting...", $outputFile);
         exit();
     }
     $postLiveIndex = $postLiveCache[$preSelectedBroadcast];
@@ -101,10 +105,10 @@ if ($preSelectedBroadcast !== '0') {
 
 @$selectedBroadcast = $storyFeed->getPostLiveItem()->getBroadcasts()[$postLiveIndex];
 if ($selectedBroadcast === null) {
-    Utils::log("Invalid Livestream ID! Exiting...");
+    Utils::log("Invalid Livestream ID! Exiting...", $outputFile);
     exit();
 }
-Utils::log("\nSelected Broadcast ID: " . $selectedBroadcast->getId());
+Utils::log("\nSelected Broadcast ID: " . $selectedBroadcast->getId(), $outputFile);
 
 if (!autoDelete && !autoInfo) {
     Utils::log("\nWhat would you selected stream? Type one of the following commands:\ninfo - Displays info about the broadcast.\ndelete - Removes the broadcast from public view.");
@@ -117,12 +121,12 @@ if (!autoDelete && !autoInfo) {
 
 switch ($cmd) {
     case 'info':
-        Utils::log("\nID: " . $selectedBroadcast->getId());
-        Utils::log("Published Date: " . date("Y-m-d H:i:s", substr($selectedBroadcast->getPublishedTime(), 0, 10)));
-        Utils::log("Expiry Date: " . date("Y-m-d H:i:s", substr($selectedBroadcast->getExpireAt(), 0, 10)));
-        Utils::log("Unique Viewers: " . $selectedBroadcast->getTotalUniqueViewerCount());
-        Utils::log("Cover Frame: " . $selectedBroadcast->getCoverFrameUrl());
-        Utils::log("Playback URL: " . $selectedBroadcast->getRtmpPlaybackUrl());
+        Utils::log("\nID: " . $selectedBroadcast->getId(), $outputFile);
+        Utils::log("Published Date: " . date("Y-m-d H:i:s", substr($selectedBroadcast->getPublishedTime(), 0, 10)), $outputFile);
+        Utils::log("Expiry Date: " . date("Y-m-d H:i:s", substr($selectedBroadcast->getExpireAt(), 0, 10)), $outputFile);
+        Utils::log("Unique Viewers: " . $selectedBroadcast->getTotalUniqueViewerCount(), $outputFile);
+        Utils::log("Cover Frame: " . $selectedBroadcast->getCoverFrameUrl(), $outputFile);
+        Utils::log("Playback URL: " . $selectedBroadcast->getRtmpPlaybackUrl(), $outputFile);
         break;
     case 'delete':
         Utils::log("\nRemoving Livestream from your Story...");

--- a/checkVod.php
+++ b/checkVod.php
@@ -1,0 +1,136 @@
+<?php
+/** @noinspection PhpUndefinedConstantInspection */
+/** @noinspection PhpComposerExtensionStubsInspection */
+
+set_time_limit(0);
+date_default_timezone_set('America/New_York');
+if (php_sapi_name() !== "cli") {
+    die("This script may not be run on a website!");
+}
+
+if (!defined('PHP_MAJOR_VERSION') || PHP_MAJOR_VERSION < 7) {
+    print("This script requires PHP version 7 or higher! Please update your php installation before attempting to run this script again!");
+    exit();
+}
+
+//Argument Processing
+$helpData = [];
+$helpData = registerArgument($helpData, $argv, "help", "Displays this message.", "h", "help");
+$helpData = registerArgument($helpData, $argv, "promptLogin", "Ignores config.php and prompts you for your username and password.", "p", "prompt-login");
+
+require_once 'utils.php';
+
+if (help) {
+    Utils::log("Command Line Arguments:");
+    foreach ($helpData as $option) {
+        $dOption = json_decode($option, true);
+        Utils::log($dOption['tacks']['mini'] . ($dOption['tacks']['full'] !== null ? " (" . $dOption['tacks']['full'] . "): " : ": ") . $dOption['description']);
+    }
+    exit();
+}
+
+Utils::existsOrError(__DIR__ . '/vendor/autoload.php', "Instagram API Files");
+Utils::existsOrError('config.php', "Username & Password Storage");
+
+require_once __DIR__ . '/vendor/autoload.php'; //Composer
+require_once 'config.php';
+
+$username = IG_USERNAME;
+$password = IG_PASS;
+if (promptLogin) {
+    Utils::log("Please enter your credentials...");
+    print "Username: ";
+    $usernameHandle = fopen("php://stdin", "r");
+    $username = trim(fgets($usernameHandle));
+    fclose($usernameHandle);
+    print "Password: ";
+    $passwordHandle = fopen("php://stdin", "r");
+    $password = trim(fgets($passwordHandle));
+    fclose($passwordHandle);
+}
+
+if ($username == "USERNAME" || $password == "PASSWORD") {
+    Utils::log("Default Username or Password have not been changed! Exiting...");
+    exit();
+}
+
+//Login to Instagram
+Utils::log("Logging into Instagram! Please wait as this can take up-to two minutes...");
+$ig = Utils::loginFlow($username, $password);
+
+Utils::log("Fetching Previous Livestreams...");
+$storyFeed = $ig->story->getUserStoryFeed($ig->account_id);
+
+if ($storyFeed->getPostLiveItem() === null || $storyFeed->getPostLiveItem()->getBroadcasts() === null) {
+    Utils::log("You do not have any saved live broadcasts :(. If you recently saved one, and you're getting this message, check back in a few minutes.");
+    exit();
+}
+
+Utils::log("Please select the livestream you want information about:");
+$postLiveIndex = 0;
+foreach ($storyFeed->getPostLiveItem()->getBroadcasts() as $broadcast) {
+    Utils::log("[$postLiveIndex] - Published At: " . date("Y-m-d H:i:s", substr($broadcast->getPublishedTime(), 0, 10)));
+    $postLiveIndex++;
+}
+print "Type the Livestream ID from the above selection...\n> ";
+$handle = fopen("php://stdin", "r");
+$postLiveIndex = trim(fgets($handle));
+fclose($handle);
+@$selectedBroadcast = $storyFeed->getPostLiveItem()->getBroadcasts()[$postLiveIndex];
+if ($selectedBroadcast === null) {
+    Utils::log("Invalid Livestream ID! Exiting...");
+    exit();
+}
+Utils::log("\nSelected Broadcast ID: " . $selectedBroadcast->getId());
+
+Utils::log("\nWhat would you selected stream? Type one of the following commands:\ninfo - Displays info about the broadcast.\ndelete - Removes the broadcast from public view.");
+$handle = fopen("php://stdin", "r");
+print "> ";
+$cmd = trim(fgets($handle));
+fclose($handle);
+
+switch ($cmd) {
+    case 'info':
+        Utils::log("\nID: " . $selectedBroadcast->getId());
+        Utils::log("Published Date: " . date("Y-m-d H:i:s", substr($selectedBroadcast->getPublishedTime(), 0, 10)));
+        Utils::log("Expiry Date: " . date("Y-m-d H:i:s", substr($selectedBroadcast->getExpireAt(), 0, 10)));
+        Utils::log("Unique Viewers: " . $selectedBroadcast->getTotalUniqueViewerCount());
+        Utils::log("Cover Frame: " . $selectedBroadcast->getCoverFrameUrl());
+        Utils::log("Playback URL: " . $selectedBroadcast->getRtmpPlaybackUrl());
+        break;
+    case 'delete':
+        Utils::log("\nRemoving Livestream from your Story...");
+        $ig->live->deletePostLive($selectedBroadcast->getId());
+        Utils::log("Removed Livestream from your Story!");
+        break;
+    default:
+        Utils::log("\nYou entered an unknown command! Exiting...");
+        break;
+}
+
+/**
+ * Registers a command line argument to a global variable.
+ * @param array $helpData The array which holds the command data for the help menu.
+ * @param array $argv The array of arguments passed to the script.
+ * @param string $name The name to be used in the global variable.
+ * @param string $description The description of the argument to be used in the help menu.
+ * @param string $tack The mini-tack argument name.
+ * @param string|null $fullTack The full-tack argument name.
+ * @return array The array of help data with the new argument.
+ */
+function registerArgument(array $helpData, array $argv, string $name, string $description, string $tack, string $fullTack = null): array
+{
+    if ($fullTack !== null) {
+        $fullTack = '--' . $fullTack;
+    }
+    define($name, in_array('-' . $tack, $argv) || in_array($fullTack, $argv));
+    array_push($helpData, json_encode([
+        'name' => $name,
+        'description' => $description,
+        'tacks' => [
+            'mini' => '-' . $tack,
+            'full' => $fullTack
+        ]
+    ]));
+    return $helpData;
+}

--- a/checkVod.php
+++ b/checkVod.php
@@ -39,14 +39,8 @@ $username = IG_USERNAME;
 $password = IG_PASS;
 if (promptLogin) {
     Utils::log("Please enter your credentials...");
-    print "Username: ";
-    $usernameHandle = fopen("php://stdin", "r");
-    $username = trim(fgets($usernameHandle));
-    fclose($usernameHandle);
-    print "Password: ";
-    $passwordHandle = fopen("php://stdin", "r");
-    $password = trim(fgets($passwordHandle));
-    fclose($passwordHandle);
+    $username = Utils::promptInput("Username:");
+    $password = Utils::promptInput("Password:");
 }
 
 if ($username == "USERNAME" || $password == "PASSWORD") {
@@ -72,10 +66,9 @@ foreach ($storyFeed->getPostLiveItem()->getBroadcasts() as $broadcast) {
     Utils::log("[$postLiveIndex] - Published At: " . date("Y-m-d H:i:s", substr($broadcast->getPublishedTime(), 0, 10)));
     $postLiveIndex++;
 }
-print "Type the Livestream ID from the above selection...\n> ";
+Utils::log("Type the Livestream ID from the above selection...");
 $handle = fopen("php://stdin", "r");
-$postLiveIndex = trim(fgets($handle));
-fclose($handle);
+$postLiveIndex = Utils::promptInput();
 @$selectedBroadcast = $storyFeed->getPostLiveItem()->getBroadcasts()[$postLiveIndex];
 if ($selectedBroadcast === null) {
     Utils::log("Invalid Livestream ID! Exiting...");
@@ -84,11 +77,7 @@ if ($selectedBroadcast === null) {
 Utils::log("\nSelected Broadcast ID: " . $selectedBroadcast->getId());
 
 Utils::log("\nWhat would you selected stream? Type one of the following commands:\ninfo - Displays info about the broadcast.\ndelete - Removes the broadcast from public view.");
-$handle = fopen("php://stdin", "r");
-print "> ";
-$cmd = trim(fgets($handle));
-fclose($handle);
-
+$cmd = Utils::promptInput();
 switch ($cmd) {
     case 'info':
         Utils::log("\nID: " . $selectedBroadcast->getId());

--- a/checkVod.php
+++ b/checkVod.php
@@ -34,7 +34,7 @@ foreach ($argv as $curArg) {
     }
 }
 
-require_once 'utils.php';
+require_once __DIR__ . '/utils.php';
 
 if (help) {
     Utils::log("Command Line Arguments:");
@@ -49,7 +49,7 @@ Utils::existsOrError(__DIR__ . '/vendor/autoload.php', "Instagram API Files");
 Utils::existsOrError('config.php', "Username & Password Storage");
 
 require_once __DIR__ . '/vendor/autoload.php'; //Composer
-require_once 'config.php';
+require_once __DIR__ . '/config.php';
 
 $username = IG_USERNAME;
 $password = IG_PASS;

--- a/commandLine.php
+++ b/commandLine.php
@@ -12,73 +12,108 @@ newCommand();
 function newCommand()
 {
     $line = Utils::promptInput("\n>");
-    if ($line == 'ecomments') {
-        sendRequest("ecomments", null);
-        Utils::log("Enabled Comments!");
-    } elseif ($line == 'dcomments') {
-        sendRequest("dcomments", null);
-        Utils::log("Disabled Comments!");
-    } elseif ($line == 'stop' || $line == 'end') {
-        $archived = "yes";
-        if (!autoArchive && !autoDiscard) {
-            Utils::log("Would you like to keep the stream archived for 24 hours? Type \"yes\" to do so or anything else to not.");
-            $archived = Utils::promptInput();
-        }
-        if (autoArchive || $archived == 'yes' && !autoDiscard) {
-            sendRequest("end", ["yes"]);
-        } else {
-            sendRequest("end", ["no"]);
-        }
-        Utils::log("Command Line Exiting! Stream *should* be ended.");
-        sleep(2);
-        exit();
-    } elseif ($line == 'pin') {
-        Utils::log("Please enter the comment id you would like to pin.");
-        $commentId = Utils::promptInput();
-        //TODO add comment id length check
-        Utils::log("Assuming that was a valid comment id, the comment should be pinned!");
-        sendRequest("pin", [$commentId]);
-    } elseif ($line == 'unpin') {
-        Utils::log("Please check the other window to see if the unpin succeeded!");
-        sendRequest("unpin", null);
-    } elseif ($line == 'pinned') {
-        Utils::log("Please check the other window to see the pinned comment!");
-        sendRequest("pinned", null);
-    } elseif ($line == 'comment') {
-        Utils::log("Please enter what you would like to comment.");
-        $text = Utils::promptInput();
-        Utils::log("Commented! Check the other window to ensure the comment was made!");
-        sendRequest("comment", [$text]);
-    } elseif ($line == 'url') {
-        Utils::log("Please check the other window for your stream url!");
-        sendRequest("url", null);
-    } elseif ($line == 'key') {
-        Utils::log("Please check the other window for your stream key!");
-        sendRequest("key", null);
-    } elseif ($line == 'info') {
-        Utils::log("Please check the other window for your stream info!");
-        sendRequest("info", null);
-    } elseif ($line == 'viewers') {
-        Utils::log("Please check the other window for your viewers list!");
-        sendRequest("viewers", null);
-    } elseif ($line == 'questions') {
-        Utils::log("Please check the other window for you questions list!");
-        sendRequest("questions", null);
-    } elseif ($line == 'showquestion') {
-        Utils::log("Please enter the question id you would like to display.");
-        $questionId = Utils::promptInput();
-        Utils::log("Please check the other window to make sure the question was displayed!");
-        sendRequest('showquestion', [$questionId]);
-    } elseif ($line == 'hidequestion') {
-        Utils::log("Please check the other window to make sure the question was removed!");
-        sendRequest('hidequestion', null);
-    } elseif ($line == 'wave') {
-        Utils::log("Please enter the user id you would like to wave at.");
-        $viewerId = Utils::promptInput();
-        Utils::log("Please check the other window to make sure the person was waved at!");
-        sendRequest('wave', [$viewerId]);
-    } elseif ($line == 'help') {
-        Utils::log("Commands:\n
+    switch ($line) {
+
+        case 'ecomments':
+            {
+                sendRequest("ecomments", null);
+                break;
+            }
+        case 'dcomments':
+            {
+                sendRequest("dcomments", null);
+                break;
+            }
+        case'stop':
+        case 'end':
+            {
+                $archived = "yes";
+                if (!autoArchive && !autoDiscard) {
+                    Utils::log("Would you like to keep the stream archived for 24 hours? Type \"yes\" to do so or anything else to not.");
+                    $archived = Utils::promptInput();
+                }
+                if (autoArchive || $archived == 'yes' && !autoDiscard) {
+                    sendRequest("end", ["yes"]);
+                } else {
+                    sendRequest("end", ["no"]);
+                }
+                Utils::log("Command Line Exiting! Stream *should* be ended.");
+                sleep(2);
+                exit();
+                break;
+            }
+        case 'pin':
+            {
+                Utils::log("Please enter the comment id you would like to pin.");
+                $commentId = Utils::promptInput();
+                //TODO add comment id length check
+                sendRequest("pin", [$commentId]);
+                break;
+            }
+        case 'unpin':
+            {
+                sendRequest("unpin", null);
+                break;
+            }
+        case 'pinned':
+            {
+                sendRequest("pinned", null);
+                break;
+            }
+        case 'comment':
+            {
+                Utils::log("Please enter what you would like to comment.");
+                $text = Utils::promptInput();
+                sendRequest("comment", [$text]);
+                break;
+            }
+        case 'url':
+            {
+                sendRequest("url", null);
+                break;
+            }
+        case 'key':
+            {
+                sendRequest("key", null);
+                break;
+            }
+        case 'info':
+            {
+                sendRequest("info", null);
+                break;
+            }
+        case 'viewers':
+            {
+                sendRequest("viewers", null);
+                break;
+            }
+        case 'questions':
+            {
+                sendRequest("questions", null);
+                break;
+            }
+        case 'showquestion':
+            {
+                Utils::log("Please enter the question id you would like to display.");
+                $questionId = Utils::promptInput();
+                sendRequest('showquestion', [$questionId]);
+                break;
+            }
+        case 'hidequestion':
+            {
+                sendRequest('hidequestion', null);
+                break;
+            }
+        case 'wave':
+            {
+                Utils::log("Please enter the user id you would like to wave at.");
+                $viewerId = Utils::promptInput();
+                sendRequest('wave', [$viewerId]);
+                break;
+            }
+        case 'help':
+            {
+                Utils::log("Commands:\n
         help - Prints this message\n
         url - Prints Stream URL\n
         key - Prints Stream Key\n
@@ -95,8 +130,13 @@ function newCommand()
         hidequestion - Hides displayed question if one is displayed\n
         wave - Waves at a user who has joined the stream\n
         stop - Stops the Live Stream");
-    } else {
-        Utils::log("Invalid Command. Type \"help\" for help!");
+                break;
+            }
+        default:
+            {
+                Utils::log("Invalid Command. Type \"help\" for help!");
+                break;
+            }
     }
     newCommand();
 }
@@ -108,6 +148,6 @@ function sendRequest(string $cmd, $values)
         'cmd' => $cmd,
         'values' => isset($values) ? $values : [],
     ]));
-    Utils::log("Please wait while we ensure the live script has received our request.");
+    Utils::log("Request Sent! Please check the other window to view the response!");
     sleep(2);
 }

--- a/commandLine.php
+++ b/commandLine.php
@@ -1,5 +1,5 @@
 <?php
-include_once 'utils.php';
+include_once __DIR__ . '/utils.php';
 define("autoArchive", in_array("-a", $argv), in_array("--auto-archive", $argv));
 define("autoDiscard", in_array("-d", $argv), in_array("--auto-discard", $argv));
 

--- a/commandLine.php
+++ b/commandLine.php
@@ -15,13 +15,17 @@ function newCommand()
     switch ($line) {
 
         case 'ecomments':
-            {
-                sendRequest("ecomments", null);
-                break;
-            }
         case 'dcomments':
+        case 'unpin':
+        case 'pinned':
+        case 'url':
+        case 'key':
+        case 'info':
+        case 'viewers':
+        case 'questions':
+        case 'hidequestion':
             {
-                sendRequest("dcomments", null);
+                sendRequest($line, null);
                 break;
             }
         case'stop':
@@ -48,60 +52,6 @@ function newCommand()
                 $commentId = Utils::promptInput();
                 //TODO add comment id length check
                 sendRequest("pin", [$commentId]);
-                break;
-            }
-        case 'unpin':
-            {
-                sendRequest("unpin", null);
-                break;
-            }
-        case 'pinned':
-            {
-                sendRequest("pinned", null);
-                break;
-            }
-        case 'comment':
-            {
-                Utils::log("Please enter what you would like to comment.");
-                $text = Utils::promptInput();
-                sendRequest("comment", [$text]);
-                break;
-            }
-        case 'url':
-            {
-                sendRequest("url", null);
-                break;
-            }
-        case 'key':
-            {
-                sendRequest("key", null);
-                break;
-            }
-        case 'info':
-            {
-                sendRequest("info", null);
-                break;
-            }
-        case 'viewers':
-            {
-                sendRequest("viewers", null);
-                break;
-            }
-        case 'questions':
-            {
-                sendRequest("questions", null);
-                break;
-            }
-        case 'showquestion':
-            {
-                Utils::log("Please enter the question id you would like to display.");
-                $questionId = Utils::promptInput();
-                sendRequest('showquestion', [$questionId]);
-                break;
-            }
-        case 'hidequestion':
-            {
-                sendRequest('hidequestion', null);
                 break;
             }
         case 'wave':

--- a/commandLine.php
+++ b/commandLine.php
@@ -1,6 +1,7 @@
 <?php
 include_once 'utils.php';
 define("autoArchive", in_array("-a", $argv), in_array("--auto-archive", $argv));
+define("autoDiscard", in_array("-d", $argv), in_array("--auto-discard", $argv));
 
 Utils::log("Please wait while while the command line ensures that the live script is properly started!");
 sleep(2);
@@ -19,11 +20,11 @@ function newCommand()
         Utils::log("Disabled Comments!");
     } elseif ($line == 'stop' || $line == 'end') {
         $archived = "yes";
-        if (!autoArchive) {
+        if (!autoArchive && !autoDiscard) {
             Utils::log("Would you like to keep the stream archived for 24 hours? Type \"yes\" to do so or anything else to not.");
             $archived = Utils::promptInput();
         }
-        if ($archived == 'yes') {
+        if (autoArchive || $archived == 'yes' && !autoDiscard) {
             sendRequest("end", ["yes"]);
         } else {
             sendRequest("end", ["no"]);

--- a/commandLine.php
+++ b/commandLine.php
@@ -28,6 +28,20 @@ function newCommand()
                 sendRequest($line, null);
                 break;
             }
+        case 'comment':
+            {
+                Utils::log("Please type what you would like to comment...");
+                $text = Utils::promptInput();
+                sendRequest("comment", [$text]);
+                break;
+            }
+        case 'showquestion':
+            {
+                Utils::log("Please enter the question id you would like to display...");
+                $questionId = Utils::promptInput();
+                sendRequest("showquestion", [$questionId]);
+                break;
+            }
         case'stop':
         case 'end':
             {

--- a/commandLine.php
+++ b/commandLine.php
@@ -10,9 +10,7 @@ newCommand();
 
 function newCommand()
 {
-    print "\n> ";
-    $handle = fopen("php://stdin", "r");
-    $line = trim(fgets($handle));
+    $line = Utils::promptInput("\n>");
     if ($line == 'ecomments') {
         sendRequest("ecomments", null);
         Utils::log("Enabled Comments!");
@@ -20,13 +18,10 @@ function newCommand()
         sendRequest("dcomments", null);
         Utils::log("Disabled Comments!");
     } elseif ($line == 'stop' || $line == 'end') {
-        fclose($handle);
         $archived = "yes";
         if (!autoArchive) {
             Utils::log("Would you like to keep the stream archived for 24 hours? Type \"yes\" to do so or anything else to not.");
-            print "> ";
-            $handle = fopen("php://stdin", "r");
-            $archived = trim(fgets($handle));
+            $archived = Utils::promptInput();
         }
         if ($archived == 'yes') {
             sendRequest("end", ["yes"]);
@@ -37,11 +32,8 @@ function newCommand()
         sleep(2);
         exit();
     } elseif ($line == 'pin') {
-        fclose($handle);
         Utils::log("Please enter the comment id you would like to pin.");
-        print "> ";
-        $handle = fopen("php://stdin", "r");
-        $commentId = trim(fgets($handle));
+        $commentId = Utils::promptInput();
         //TODO add comment id length check
         Utils::log("Assuming that was a valid comment id, the comment should be pinned!");
         sendRequest("pin", [$commentId]);
@@ -52,11 +44,8 @@ function newCommand()
         Utils::log("Please check the other window to see the pinned comment!");
         sendRequest("pinned", null);
     } elseif ($line == 'comment') {
-        fclose($handle);
         Utils::log("Please enter what you would like to comment.");
-        print "> ";
-        $handle = fopen("php://stdin", "r");
-        $text = trim(fgets($handle));
+        $text = Utils::promptInput();
         Utils::log("Commented! Check the other window to ensure the comment was made!");
         sendRequest("comment", [$text]);
     } elseif ($line == 'url') {
@@ -75,22 +64,16 @@ function newCommand()
         Utils::log("Please check the other window for you questions list!");
         sendRequest("questions", null);
     } elseif ($line == 'showquestion') {
-        fclose($handle);
         Utils::log("Please enter the question id you would like to display.");
-        print "> ";
-        $handle = fopen("php://stdin", "r");
-        $questionId = trim(fgets($handle));
+        $questionId = Utils::promptInput();
         Utils::log("Please check the other window to make sure the question was displayed!");
         sendRequest('showquestion', [$questionId]);
     } elseif ($line == 'hidequestion') {
         Utils::log("Please check the other window to make sure the question was removed!");
         sendRequest('hidequestion', null);
     } elseif ($line == 'wave') {
-        fclose($handle);
         Utils::log("Please enter the user id you would like to wave at.");
-        print "> ";
-        $handle = fopen("php://stdin", "r");
-        $viewerId = trim(fgets($handle));
+        $viewerId = Utils::promptInput();
         Utils::log("Please check the other window to make sure the person was waved at!");
         sendRequest('wave', [$viewerId]);
     } elseif ($line == 'help') {
@@ -114,7 +97,6 @@ function newCommand()
     } else {
         Utils::log("Invalid Command. Type \"help\" for help!");
     }
-    fclose($handle);
     newCommand();
 }
 

--- a/commandLine.php
+++ b/commandLine.php
@@ -42,7 +42,7 @@ function newCommand()
                 sendRequest("showquestion", [$questionId]);
                 break;
             }
-        case'stop':
+        case 'stop':
         case 'end':
             {
                 $archived = "yes";
@@ -50,14 +50,10 @@ function newCommand()
                     Utils::log("Would you like to keep the stream archived for 24 hours? Type \"yes\" to do so or anything else to not.");
                     $archived = Utils::promptInput();
                 }
-                if (autoArchive || $archived == 'yes' && !autoDiscard) {
-                    sendRequest("end", ["yes"]);
-                } else {
-                    sendRequest("end", ["no"]);
-                }
+                sendRequest("end", [(autoArchive || $archived == 'yes' && !autoDiscard) ? "yes" : "no"]);
                 Utils::log("Command Line Exiting! Stream *should* be ended.");
                 sleep(2);
-                exit();
+                exit(1);
                 break;
             }
         case 'pin':

--- a/config.php
+++ b/config.php
@@ -3,11 +3,19 @@
 define('IG_USERNAME', 'USERNAME');
 define('IG_PASS', 'PASSWORD');
 
+/*
+ * Settings below this line are optional!
+ */
+
 //OBS Settings
 define('OBS_BITRATE', '4000');
+
+define('OBS_CUSTOM_PATH', 'INSERT_PATH'); //**OPTIONAL** Specify a custom path for the script to search for an obs executable
+define('OBS_EXEC_NAME', 'obs64.exe'); //Recommend you don't touch this unless you modify the custom path & know what you're doing
+
 define('OBS_X', '720'); //You shouldn't touch this
 define('OBS_Y', '1280'); //You shouldn't touch this
 
 
 //Config Metadata
-define('configVersionCode', '3'); //You shouldn't touch this
+define('configVersionCode', '4'); //You shouldn't touch this

--- a/goLive.php
+++ b/goLive.php
@@ -562,7 +562,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
             exit();
         }
 
-        sleep(1);
+        sleep(2);
     } while (!$exit);
 }
 

--- a/goLive.php
+++ b/goLive.php
@@ -54,7 +54,7 @@ define("scriptFlavor", "beta");
 Utils::log("Loading InstagramLive-PHP v" . scriptVersion . "...");
 
 if (Utils::checkForUpdate(scriptVersionCode, scriptFlavor)) {
-    Utils::log("Update: A new update is available, run the `update.php` script to fetch it!");
+    Utils::log("\nUpdate: A new update is available, run the `update.php` script to fetch it!\n");
 }
 
 if (dumpFlavor) {

--- a/goLive.php
+++ b/goLive.php
@@ -102,14 +102,8 @@ function main($console, ObsHelper $helper, $streamTotalSec, $autoPin)
     $password = IG_PASS;
     if (promptLogin) {
         Utils::log("Please enter your credentials...");
-        print "Username: ";
-        $usernameHandle = fopen("php://stdin", "r");
-        $username = trim(fgets($usernameHandle));
-        fclose($usernameHandle);
-        print "Password: ";
-        $passwordHandle = fopen("php://stdin", "r");
-        $password = trim(fgets($passwordHandle));
-        fclose($passwordHandle);
+        $username = Utils::promptInput("Username:");
+        $password = Utils::promptInput("Password:");
     }
 
     if ($username == "USERNAME" || $password == "PASSWORD") {
@@ -152,11 +146,7 @@ function main($console, ObsHelper $helper, $streamTotalSec, $autoPin)
         } else {
             if (!obsAutomationAccept) {
                 Utils::log("OBS Integration: Would you like the script to automatically start streaming to OBS? Type \"yes\" or press enter to ignore.");
-                print "> ";
-                $eoiH = fopen("php://stdin", "r");
-                $eoi = trim(fgets($eoiH));
-                fclose($eoiH);
-                if ($eoi !== "yes") {
+                if (Utils::promptInput() !== "yes") {
                     $obsAutomation = false;
                 }
             }
@@ -197,18 +187,14 @@ function main($console, ObsHelper $helper, $streamTotalSec, $autoPin)
                     Utils::log("OBS Integration: OBS Launched Successfully! Starting Stream...");
                 } else {
                     Utils::log("OBS Integration: OBS was not detected! Press enter once you confirm OBS is streaming...");
-                    $oPauseH = fopen("php://stdin", "r");
-                    fgets($oPauseH);
-                    fclose($oPauseH);
+                    Utils::promptInput("");
                 }
             }
         }
 
         if (!$obsAutomation || obsNoStream || $helper->slobsPresent) {
             Utils::log("Please" . ($helper->slobsPresent ? " launch Streamlabs OBS and " : " ") . "start streaming to the url and key above! Once you are live, please press enter!");
-            $pauseH = fopen("php://stdin", "r");
-            fgets($pauseH);
-            fclose($pauseH);
+            Utils::promptInput("");
         }
 
         $ig->live->start($broadcastId);
@@ -503,10 +489,8 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
 
             $archived = "yes";
             if (!autoArchive) {
-                print "Would you like to archive this stream?\n> ";
-                $handle = fopen("php://stdin", "r");
-                $archived = trim(fgets($handle));
-                fclose($handle);
+                Utils::log("Would you like to archive this stream?");
+                $archived = Utils::promptInput();
             }
             if ($archived == 'yes') {
                 Utils::log("Adding to Archive...");
@@ -534,10 +518,8 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
             Utils::log("Stream has ended due to Instagram's one hour time limit!");
             $archived = "yes";
             if (!autoArchive) {
-                print "Would you like to archive this stream?\n> ";
-                $handle = fopen("php://stdin", "r");
-                $archived = trim(fgets($handle));
-                fclose($handle);
+                Utils::log("Would you like to archive this stream?");
+                $archived = Utils::promptInput();
             }
             if ($archived == 'yes') {
                 Utils::log("Adding to Archive...");
@@ -547,10 +529,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
             $restart = "yes";
             if (!infiniteStream) {
                 Utils::log("Would you like to go live again?");
-                print "> ";
-                $handle = fopen("php://stdin", "r");
-                $restart = trim(fgets($handle));
-                fclose($handle);
+                $restart = Utils::promptInput();
             }
             if ($restart == 'yes') {
                 Utils::log("Restarting Livestream!");
@@ -578,9 +557,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
 function newCommand(Live $live, $broadcastId, $streamUrl, $streamKey, bool $obsAuto, ObsHelper $helper)
 {
     print "\n> ";
-    $handle = fopen("php://stdin", "r");
-    $line = trim(fgets($handle));
-    fclose($handle);
+    $line = Utils::promptInput();
     if ($line == 'ecomments') {
         $live->enableComments($broadcastId);
         Utils::log("Enabled Comments!");
@@ -588,7 +565,6 @@ function newCommand(Live $live, $broadcastId, $streamUrl, $streamKey, bool $obsA
         $live->disableComments($broadcastId);
         Utils::log("Disabled Comments!");
     } elseif ($line == 'stop' || $line == 'end') {
-        fclose($handle);
         if ($obsAuto) {
             Utils::log("OBS Integration: Killing OBS...");
             $helper->killOBS();
@@ -604,10 +580,7 @@ function newCommand(Live $live, $broadcastId, $streamUrl, $streamKey, bool $obsA
         $archived = "yes";
         if (!autoArchive) {
             Utils::log("Would you like to keep the stream archived for 24 hours? Type \"yes\" to do so or anything else to not.");
-            print "> ";
-            $handle = fopen("php://stdin", "r");
-            $archived = trim(fgets($handle));
-            fclose($handle);
+            $archived = Utils::promptInput();
         }
         if ($archived == 'yes') {
             Utils::log("Adding to Archive!");
@@ -645,10 +618,7 @@ function newCommand(Live $live, $broadcastId, $streamUrl, $streamKey, bool $obsA
         }
     } elseif ($line == 'wave') {
         Utils::log("Please enter the user id you would like to wave at.");
-        print "> ";
-        $handle = fopen("php://stdin", "r");
-        $viewerId = trim(fgets($handle));
-        fclose($handle);
+        $viewerId = Utils::promptInput();
         try {
             $live->wave($broadcastId, $viewerId);
             Utils::log("Waved at a user!");
@@ -658,10 +628,7 @@ function newCommand(Live $live, $broadcastId, $streamUrl, $streamKey, bool $obsA
         }
     } elseif ($line == 'comment') {
         Utils::log("Please enter the text you wish to comment.");
-        print "> ";
-        $handle = fopen("php://stdin", "r");
-        $text = trim(fgets($handle));
-        fclose($handle);
+        $text = Utils::promptInput();
         if ($text !== "") {
             $live->comment($broadcastId, $text);
             Utils::log("Commented on stream!");
@@ -673,7 +640,6 @@ function newCommand(Live $live, $broadcastId, $streamUrl, $streamKey, bool $obsA
     } else {
         Utils::log("Invalid Command. Type \"help\" for help!");
     }
-    @fclose($handle);
     newCommand($live, $broadcastId, $streamUrl, $streamKey, $obsAuto, $helper);
 }
 

--- a/goLive.php
+++ b/goLive.php
@@ -51,7 +51,7 @@ foreach ($argv as $curArg) {
 require_once 'utils.php';
 
 define("scriptVersion", "1.5");
-define("scriptVersionCode", "33");
+define("scriptVersionCode", "34");
 define("scriptFlavor", "beta");
 Utils::log("Loading InstagramLive-PHP v" . scriptVersion . "...");
 

--- a/goLive.php
+++ b/goLive.php
@@ -51,8 +51,8 @@ foreach ($argv as $curArg) {
 require_once __DIR__ . '/utils.php';
 
 define("scriptVersion", "1.5");
-define("scriptVersionCode", "36");
-define("scriptFlavor", "beta");
+define("scriptVersionCode", "37");
+define("scriptFlavor", "stable");
 
 if (dumpFlavor) {
     Utils::log(scriptFlavor);

--- a/goLive.php
+++ b/goLive.php
@@ -46,7 +46,7 @@ foreach ($argv as $curArg) {
 }
 
 //Load Utils
-require 'utils.php';
+require_once 'utils.php';
 
 define("scriptVersion", "1.5");
 define("scriptVersionCode", "32");
@@ -82,8 +82,8 @@ Utils::existsOrError('obs.php', "OBS Integration");
 Utils::existsOrError('config.php', "Username & Password Storage");
 
 //Load Classes
-require __DIR__ . '/vendor/autoload.php'; //Composer
-require 'obs.php'; //OBS Utils
+require_once __DIR__ . '/vendor/autoload.php'; //Composer
+require_once 'obs.php'; //OBS Utils
 
 use InstagramAPI\Instagram;
 use InstagramAPI\Exception\ChallengeRequiredException;

--- a/goLive.php
+++ b/goLive.php
@@ -71,8 +71,9 @@ if (Utils::checkForUpdate(scriptVersionCode, scriptFlavor)) {
 }
 
 if (!Utils::isApiDevMaster()) {
-    Utils::log("You're using an outdated Instagram-API Version! Forcing an update...");
+    Utils::log("Outdated Instagram-API version detected, attempting to fix this for you. This may take a while...");
     exec(PHP_BINARY . " update.php");
+    Utils::log("Update Finished! Exiting the script, please re-run the script now.");
     exit();
 }
 

--- a/goLive.php
+++ b/goLive.php
@@ -48,9 +48,9 @@ foreach ($argv as $curArg) {
 //Load Utils
 require 'utils.php';
 
-define("scriptVersion", "1.4");
-define("scriptVersionCode", "31");
-define("scriptFlavor", "stable");
+define("scriptVersion", "1.5");
+define("scriptVersionCode", "32");
+define("scriptFlavor", "beta");
 Utils::log("Loading InstagramLive-PHP v" . scriptVersion . "...");
 
 if (Utils::checkForUpdate(scriptVersionCode, scriptFlavor)) {

--- a/goLive.php
+++ b/goLive.php
@@ -347,7 +347,7 @@ function main($console, ObsHelper $helper, $streamTotalSec, $autoPin)
         }
 
         Utils::log("Unable to start command lines, attempting clean up!");
-        $ig->live->getFinalViewerList($broadcastId);
+        parseFinalViewers($ig->live->getFinalViewerList($broadcastId)->getUsers());
         $ig->live->end($broadcastId);
         Utils::dump();
         exit();
@@ -381,12 +381,23 @@ function addComment(Comment $comment, bool $system = false)
  */
 function parseFinalViewers($users)
 {
+    $finalViewers = '';
+    $finalViewersCount = 0;
+    foreach ($users as $user) {
+        $finalViewers = $finalViewers . '@' . $user->getUsername() . ', ';
+        $finalViewersCount++;
+    }
+    $finalViewers = rtrim($finalViewers, " ,");
+
+    if ($finalViewers !== '') {
+        Utils::log("$finalViewersCount Final Viewer(s): $finalViewers");
+    } else {
+        Utils::log("Your stream had no viewers :(");
+    }
+
+
     if (logCommentOutput) {
-        $finalViewers = 'Final Viewers: ';
-        foreach ($users as $user) {
-            $finalViewers = $finalViewers . $user->getUsername() . ', ';
-        }
-        Utils::logOutput($finalViewers);
+        Utils::logOutput("$finalViewersCount Final Viewer(s): $finalViewers");
     }
 }
 

--- a/goLive.php
+++ b/goLive.php
@@ -346,7 +346,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
                         Utils::log("Livestream added to Archive!");
                     }
                     Utils::log("Ended stream!");
-                    unlink(__DIR__ . '/request');
+                    @unlink(__DIR__ . '/request');
                     sleep(2);
                     exit();
                 } elseif ($cmd == 'pin') {
@@ -441,7 +441,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
                         Utils::dump($waveError->getMessage());
                     }
                 }
-                unlink(__DIR__ . '/request');
+                @unlink(__DIR__ . '/request');
             } catch (Exception $cmdExc) {
                 echo 'Error While Executing Command: ' . $cmdExc->getMessage() . "\n";
                 Utils::dump($cmdExc->getMessage());

--- a/goLive.php
+++ b/goLive.php
@@ -50,7 +50,7 @@ foreach ($argv as $curArg) {
 require_once 'utils.php';
 
 define("scriptVersion", "1.5");
-define("scriptVersionCode", "32");
+define("scriptVersionCode", "33");
 define("scriptFlavor", "beta");
 Utils::log("Loading InstagramLive-PHP v" . scriptVersion . "...");
 

--- a/goLive.php
+++ b/goLive.php
@@ -53,6 +53,17 @@ require_once 'utils.php';
 define("scriptVersion", "1.5");
 define("scriptVersionCode", "34");
 define("scriptFlavor", "beta");
+
+if (dumpFlavor) {
+    Utils::log(scriptFlavor);
+    exit();
+}
+
+if (dump) {
+    Utils::dump();
+    exit();
+}
+
 Utils::log("Loading InstagramLive-PHP v" . scriptVersion . "...");
 
 if (Utils::checkForUpdate(scriptVersionCode, scriptFlavor)) {

--- a/goLive.php
+++ b/goLive.php
@@ -232,7 +232,7 @@ function main($console, ObsHelper $helper, $streamTotalSec, $autoPin)
         }
 
         Utils::log("Unable to start command lines, attempting clean up!");
-        parseFinalViewers($ig->live->getFinalViewerList($broadcastId)->getUsers());
+        parseFinalViewers($ig->live->getFinalViewerList($broadcastId));
         $ig->live->end($broadcastId);
         Utils::dump();
         exit();
@@ -262,27 +262,26 @@ function addComment(Comment $comment, bool $system = false)
 }
 
 /**
- * @param \InstagramAPI\Response\Model\User[] $users
+ * @param \InstagramAPI\Response\FinalViewerListResponse $finalResponse
  */
-function parseFinalViewers($users)
+function parseFinalViewers($finalResponse)
 {
     $finalViewers = '';
-    $finalViewersCount = 0;
-    foreach ($users as $user) {
+    foreach ($finalResponse->getUsers() as $user) {
         $finalViewers = $finalViewers . '@' . $user->getUsername() . ', ';
-        $finalViewersCount++;
     }
     $finalViewers = rtrim($finalViewers, " ,");
 
-    if ($finalViewers !== '') {
-        Utils::log("$finalViewersCount Final Viewer(s): $finalViewers");
+    if ($finalResponse->getTotalUniqueViewerCount() > 0) {
+        Utils::log($finalResponse->getTotalUniqueViewerCount() . " Final Viewer(s).");
+        Utils::log("Top Viewers: $finalViewers");
     } else {
         Utils::log("Your stream had no viewers :(");
     }
 
 
     if (logCommentOutput) {
-        Utils::logOutput("$finalViewersCount Final Viewer(s): $finalViewers");
+        Utils::logOutput($finalResponse->getTotalUniqueViewerCount() . " Final Viewer(s): $finalViewers");
     }
 }
 
@@ -339,7 +338,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
                     $archived = $values[0];
                     Utils::log("Wrapping up and exiting...");
                     //Needs this to retain, I guess?
-                    parseFinalViewers($ig->live->getFinalViewerList($broadcastId)->getUsers());
+                    parseFinalViewers($ig->live->getFinalViewerList($broadcastId));
                     $ig->live->end($broadcastId);
                     if ($archived == 'yes') {
                         $ig->live->addToPostLive($broadcastId);
@@ -498,7 +497,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
                 Utils::log("OBS Integration: Restoring old service.json...");
                 $helper->resetServiceState();
             }
-            parseFinalViewers($ig->live->getFinalViewerList($broadcastId)->getUsers());
+            parseFinalViewers($ig->live->getFinalViewerList($broadcastId));
             $ig->live->end($broadcastId);
             Utils::log("Stream has ended due to user requested stream limit of $streamTotalSec seconds!");
 
@@ -530,7 +529,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
                 Utils::log("OBS Integration: Restoring old service.json...");
                 $helper->resetServiceState();
             }
-            parseFinalViewers($ig->live->getFinalViewerList($broadcastId)->getUsers());
+            parseFinalViewers($ig->live->getFinalViewerList($broadcastId));
             $ig->live->end($broadcastId);
             Utils::log("Stream has ended due to Instagram's one hour time limit!");
             $archived = "yes";
@@ -599,7 +598,7 @@ function newCommand(Live $live, $broadcastId, $streamUrl, $streamKey, bool $obsA
             $helper->resetServiceState();
         }
         //Needs this to retain, I guess?
-        parseFinalViewers($live->getFinalViewerList($broadcastId)->getUsers());
+        parseFinalViewers($live->getFinalViewerList($broadcastId));
         $live->end($broadcastId);
         Utils::log("Stream Ended!");
         $archived = "yes";

--- a/goLive.php
+++ b/goLive.php
@@ -213,14 +213,14 @@ function main($console, ObsHelper $helper, $streamTotalSec, $autoPin)
 
         $ig->live->start($broadcastId);
 
-        if (startDisableComments) {
-            $ig->live->disableComments($broadcastId);
-            Utils::log("Automatically Disabled Comments!");
-        }
-
         if ($autoPin !== null) {
             $ig->live->pinComment($broadcastId, $ig->live->comment($broadcastId, $autoPin)->getComment()->getPk());
             Utils::log("Automatically Pinned a Comment!");
+        }
+
+        if (startDisableComments) {
+            $ig->live->disableComments($broadcastId);
+            Utils::log("Automatically Disabled Comments!");
         }
 
         if ((Utils::isWindows() || bypassCheck) && !forceLegacy) {

--- a/goLive.php
+++ b/goLive.php
@@ -48,7 +48,7 @@ foreach ($argv as $curArg) {
 }
 
 //Load Utils
-require_once 'utils.php';
+require_once __DIR__ . '/utils.php';
 
 define("scriptVersion", "1.5");
 define("scriptVersionCode", "34");
@@ -87,19 +87,18 @@ if (help) {
 
 //Check for required files
 Utils::existsOrError(__DIR__ . '/vendor/autoload.php', "Instagram API Files");
-Utils::existsOrError('obs.php', "OBS Integration");
-Utils::existsOrError('config.php', "Username & Password Storage");
+Utils::existsOrError(__DIR__ . '/obs.php', "OBS Integration");
+Utils::existsOrError(__DIR__ . '/config.php', "Username & Password Storage");
 
 //Load Classes
 require_once __DIR__ . '/vendor/autoload.php'; //Composer
-require_once 'obs.php'; //OBS Utils
+require_once __DIR__ . '/obs.php'; //OBS Utils
+require_once __DIR__ . '/config.php';
 
 use InstagramAPI\Instagram;
 use InstagramAPI\Request\Live;
 use InstagramAPI\Response\Model\User;
 use InstagramAPI\Response\Model\Comment;
-
-require_once 'config.php';
 
 //Run the script and spawn a new console window if applicable.
 main(true, new ObsHelper(!obsNoStream, disableObsAutomation, forceSlobs), $streamTotalSec, $autoPin);
@@ -201,7 +200,7 @@ function main($console, ObsHelper $helper, $streamTotalSec, $autoPin)
         }
 
         if (!$obsAutomation || obsNoStream || $helper->slobsPresent) {
-            Utils::log("Please" . ($helper->slobsPresent ? " launch Streamlabs OBS and " : " ") . "start streaming to the url and key above! Once you are live, please press enter!");
+            Utils::log("Please " . ($helper->slobsPresent ? "launch Streamlabs OBS and " : " ") . "start streaming to the url and key above! Once you are live, please press enter!");
             Utils::promptInput("");
         }
 

--- a/goLive.php
+++ b/goLive.php
@@ -1,4 +1,5 @@
-<?php /** @noinspection PhpComposerExtensionStubsInspection */
+<?php
+/** @noinspection PhpComposerExtensionStubsInspection */
 /** @noinspection PhpUndefinedConstantInspection */
 
 set_time_limit(0);
@@ -694,7 +695,6 @@ function registerArgument(array $helpData, array $argv, string $name, string $de
         $fullTack = '--' . $fullTack;
     }
     define($name, in_array('-' . $tack, $argv) || in_array($fullTack, $argv));
-    /** @noinspection PhpComposerExtensionStubsInspection */
     array_push($helpData, json_encode([
         'name' => $name,
         'description' => $description,

--- a/goLive.php
+++ b/goLive.php
@@ -51,7 +51,7 @@ foreach ($argv as $curArg) {
 require_once __DIR__ . '/utils.php';
 
 define("scriptVersion", "1.5");
-define("scriptVersionCode", "35");
+define("scriptVersionCode", "36");
 define("scriptFlavor", "beta");
 
 if (dumpFlavor) {

--- a/goLive.php
+++ b/goLive.php
@@ -59,13 +59,9 @@ if (Utils::checkForUpdate(scriptVersionCode, scriptFlavor)) {
     Utils::log("\nUpdate: A new update is available, run the `update.php` script to fetch it!\n");
 }
 
-if (dumpFlavor) {
-    Utils::log(scriptFlavor);
-    exit();
-}
-
-if (dump) {
-    Utils::dump();
+if (!Utils::isApiDevMaster()) {
+    Utils::log("You're using an outdated Instagram-API Version! Forcing an update...");
+    exec(PHP_BINARY . " update.php");
     exit();
 }
 

--- a/goLive.php
+++ b/goLive.php
@@ -32,7 +32,7 @@ $helpData = registerArgument($helpData, $argv, "thisIsAPlaceholder", "Sets the a
 $helpData = registerArgument($helpData, $argv, "thisIsAPlaceholder1", "Automatically pins a comment when the live stream starts. Note: Use underscores for spaces. (Example: --auto-pin=Hello_World!).", "-auto-pin");
 $helpData = registerArgument($helpData, $argv, "forceSlobs", "Forces OBS Integration to prefer Streamlabs OBS over normal OBS.", "-streamlabs-obs");
 $helpData = registerArgument($helpData, $argv, "promptLogin", "Ignores config.php and prompts you for your username and password.", "p", "prompt-login");
-$helpData = registerArgument($helpData, $argv, "dump", "Forces an error dump for debug purposes.", "d", "dump");
+$helpData = registerArgument($helpData, $argv, "dump", "Forces an error dump for debug purposes.", "-dump");
 $helpData = registerArgument($helpData, $argv, "dumpFlavor", "Dumps current release flavor.", "-dumpFlavor");
 
 $streamTotalSec = 0;

--- a/goLive.php
+++ b/goLive.php
@@ -51,7 +51,7 @@ foreach ($argv as $curArg) {
 require_once __DIR__ . '/utils.php';
 
 define("scriptVersion", "1.5");
-define("scriptVersionCode", "34");
+define("scriptVersionCode", "35");
 define("scriptFlavor", "beta");
 
 if (dumpFlavor) {

--- a/obs.php
+++ b/obs.php
@@ -39,7 +39,10 @@ class ObsHelper
         }
 
         clearstatcache();
-        if (@file_exists("C:/Program Files/obs-studio/") && !$forceStreamlabs) {
+        //Because never trust user input...
+        if (OBS_CUSTOM_PATH !== 'INSERT_PATH' && @file_exists((substr(str_replace('\\', '/', OBS_CUSTOM_PATH), -1) === '/' ? str_replace("\\", '/', OBS_CUSTOM_PATH) : str_replace("\\", '/', OBS_CUSTOM_PATH) . '/'))) {
+            $this->obs_path = (substr(str_replace('\\', '/', OBS_CUSTOM_PATH), -1) === '/' ? str_replace("\\", '/', OBS_CUSTOM_PATH) : str_replace("\\", '/', OBS_CUSTOM_PATH) . '/');
+        } else if (@file_exists("C:/Program Files/obs-studio/") && !$forceStreamlabs) {
             $this->obs_path = "C:/Program Files/obs-studio/";
         } elseif (@file_exists("C:/Program Files (x86)/obs-studio/") && !$forceStreamlabs) {
             $this->obs_path = "C:/Program Files (x86)/obs-studio/";
@@ -223,9 +226,9 @@ class ObsHelper
     public function killOBS(): bool
     {
         if ($this->slobsPresent) {
-            return strpos(shell_exec("taskkill /IM \"crash-handler-process.exe\" /F && taskkill /IM \"crashpad_handler.exe\" /F && taskkill /IM \"Streamlabs OBS.exe\" /F && taskkill /IM obs64.exe /F"), "SUCCESS");
+            return strpos(shell_exec("taskkill /IM \"crash-handler-process.exe\" /F && taskkill /IM \"crashpad_handler.exe\" /F && taskkill /IM \"Streamlabs OBS.exe\" /F && taskkill /IM " . OBS_EXEC_NAME . " /F"), "SUCCESS");
         }
-        return strpos(shell_exec("taskkill /IM obs64.exe /F"), "SUCCESS");
+        return strpos(shell_exec("taskkill /IM " . OBS_EXEC_NAME . " /F"), "SUCCESS");
     }
 
     /**
@@ -238,7 +241,7 @@ class ObsHelper
             pclose(popen("cd \"$this->obs_path\" && start /B \"Streamlabs OBS.exe\"", "r"));
             return true;
         }
-        pclose(popen("cd \"$this->obs_path" . "bin/64bit\" && start /B obs64.exe" . ($this->autoStream ? " --startstreaming" : "") . " --profile $this->profile_name", "r"));
+        pclose(popen("cd \"$this->obs_path" . "bin/64bit\" && start /B " . OBS_EXEC_NAME . ($this->autoStream ? " --startstreaming" : "") . " --profile $this->profile_name", "r"));
         return true;
     }
 
@@ -248,7 +251,7 @@ class ObsHelper
      */
     public function isObsRunning(): bool
     {
-        $res = shell_exec("tasklist /FI \"IMAGENAME eq obs64.exe\" 2>NUL | find /I /N \"obs64.exe\">NUL && if \"%ERRORLEVEL%\"==\"0\" echo running");
+        $res = shell_exec("tasklist /FI \"IMAGENAME eq " . OBS_EXEC_NAME . "\" 2>NUL | find /I /N \"" . OBS_EXEC_NAME . "\">NUL && if \"%ERRORLEVEL%\"==\"0\" echo running");
         if (strcmp($res, "") !== 0) {
             return true;
         }

--- a/obs.php
+++ b/obs.php
@@ -1,7 +1,7 @@
 <?php /** @noinspection PhpComposerExtensionStubsInspection */
 
-require_once 'config.php';
-require_once 'utils.php';
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/utils.php';
 
 class ObsHelper
 {

--- a/obs.php
+++ b/obs.php
@@ -75,9 +75,8 @@ class ObsHelper
                 Utils::log("[$profileIndex] - " . str_replace(getenv("appdata") . "\obs-studio\basic\profiles\\", '', $curProfile));
                 $profileIndex++;
             }
-            print "OBS Integration: Type your Profile ID from the above selection...\n>";
-            $handle = fopen("php://stdin", "r");
-            $profileIndex = trim(fgets($handle));
+            Utils::log("OBS Integration: Type your Profile ID from the above selection...");
+            $profileIndex = Utils::promptInput();
             @$profile = $profiles[$profileIndex];
             if ($profile === null) {
                 Utils::log("OBS Integration: Invalid Profile Selection!");

--- a/obs.php
+++ b/obs.php
@@ -42,7 +42,7 @@ class ObsHelper
         //Because never trust user input...
         if (OBS_CUSTOM_PATH !== 'INSERT_PATH' && @file_exists((substr(str_replace('\\', '/', OBS_CUSTOM_PATH), -1) === '/' ? str_replace("\\", '/', OBS_CUSTOM_PATH) : str_replace("\\", '/', OBS_CUSTOM_PATH) . '/'))) {
             $this->obs_path = (substr(str_replace('\\', '/', OBS_CUSTOM_PATH), -1) === '/' ? str_replace("\\", '/', OBS_CUSTOM_PATH) : str_replace("\\", '/', OBS_CUSTOM_PATH) . '/');
-        } else if (@file_exists("C:/Program Files/obs-studio/") && !$forceStreamlabs) {
+        } elseif (@file_exists("C:/Program Files/obs-studio/") && !$forceStreamlabs) {
             $this->obs_path = "C:/Program Files/obs-studio/";
         } elseif (@file_exists("C:/Program Files (x86)/obs-studio/") && !$forceStreamlabs) {
             $this->obs_path = "C:/Program Files (x86)/obs-studio/";
@@ -64,12 +64,12 @@ class ObsHelper
             return;
         }
 
-        $profiles = $dirs = array_filter(glob(getenv("appdata") . "\obs-studio\basic\profiles\*"), 'is_dir');
+        $profiles = array_filter(glob(getenv("appdata") . "\obs-studio\basic\profiles\*"), 'is_dir');
         $profile = null;
         if (count($profiles) === 0) {
             $this->obs_path = null;
             return;
-        } else if (count($profiles) === 1) {
+        } elseif (count($profiles) === 1) {
             $profile = $profiles[0];
         } else {
             Utils::log("OBS Integration: Multi-Profile environment detected! Please select your current OBS profile.");
@@ -197,11 +197,10 @@ class ObsHelper
             if (!$bitRateTriggered) {
                 $newLines = $newLines . "[SimpleOutput]\nVBitrate" . OBS_BITRATE . "\n";
             }
-        } else {
-            Utils::log("OBS Integration: Unable to modify settings!");
+            @file_put_contents($this->settings_path, $newLines);
+            return;
         }
-
-        @file_put_contents($this->settings_path, $newLines);
+        Utils::log("OBS Integration: Unable to modify settings!");
     }
 
     /**

--- a/update.php
+++ b/update.php
@@ -1,12 +1,17 @@
 <?php /** @noinspection PhpComposerExtensionStubsInspection */
 
-if (exec(PHP_BINARY . " goLive.php --dumpFlavor") == 'custom') {
+logTxt("Loading Updater...");
+if (file_exists('goLive.php')) {
+    $cachedFlavor = exec(PHP_BINARY . " goLive.php --dumpFlavor");
+}
+
+if (@$cachedFlavor == 'custom') {
     logTxt("Custom build flavor located! Exiting updater...");
     exit();
 }
 
 $beta = false;
-if (exec(PHP_BINARY . " goLive.php --dumpFlavor") == 'beta') {
+if (@$cachedFlavor == 'beta') {
     $beta = true;
 }
 if (in_array('-b', $argv) || in_array('--beta', $argv)) {

--- a/utils.php
+++ b/utils.php
@@ -9,12 +9,27 @@ use InstagramAPI\Instagram;
 
 class Utils
 {
+    /**
+     * Checks the current version code against the server's version code.
+     * @param string $current The current version code.
+     * @param string $flavor The current version flavor.
+     * @return bool Returns true if update is available.
+     */
     public static function checkForUpdate(string $current, string $flavor): bool
     {
         if ($flavor == "custom") {
             return false;
         }
         return (int)json_decode(file_get_contents("https://raw.githubusercontent.com/JRoy/InstagramLive-PHP/update/$flavor.json"), true)['versionCode'] > (int)$current;
+    }
+
+    /**
+     * Checks if the script is using dev-master
+     * @return bool Returns true if composer is using dev-master
+     */
+    public static function isApiDevMaster(): bool
+    {
+        return self::startsWith(@json_decode(file_get_contents('composer.json'), true)['require']['mgp25/instagram-php'], 'dev-master');
     }
 
     /**
@@ -37,6 +52,7 @@ class Utils
         self::log("===========BEGIN DUMP===========");
         self::log("InstagramLive-PHP Version: " . scriptVersion);
         self::log("InstagramLive-PHP Flavor: " . scriptFlavor);
+        self::log("Instagram-API Version: " . @json_decode(file_get_contents('composer.json'), true)['require']['mgp25/instagram-php']);
         self::log("Operating System: " . PHP_OS);
         self::log("PHP Version: " . PHP_VERSION);
         self::log("PHP Runtime: " . php_sapi_name());

--- a/utils.php
+++ b/utils.php
@@ -1,7 +1,5 @@
 <?php
-
 /** @noinspection PhpUndefinedConstantInspection */
-
 /** @noinspection PhpComposerExtensionStubsInspection */
 
 require_once __DIR__ . '/vendor/autoload.php';

--- a/utils.php
+++ b/utils.php
@@ -105,7 +105,7 @@ class Utils
             self::log("The following file, `" . $path . "` is required and not found by the script for the following reason: " . $reason);
             self::log("Please make sure you follow the setup guide correctly.");
             self::dump();
-            exit();
+            exit(1);
         }
     }
 
@@ -167,7 +167,7 @@ class Utils
                     if ($attemptBypass !== 'yes') {
                         self::log("Suspicious Login: Account Challenge Failed :(.");
                         self::dump();
-                        exit();
+                        exit(1);
                     }
                     self::log("Preparing to verify account...");
                     sleep(3);
@@ -180,7 +180,7 @@ class Utils
                         $verification_method = 1;
                     } else {
                         self::log("Aborting!");
-                        exit();
+                        exit(1);
                     }
 
                     /** @noinspection PhpUndefinedMethodInspection */
@@ -199,7 +199,7 @@ class Utils
                         if ($customResponse['status'] === 'ok' && isset($customResponse['action'])) {
                             if ($customResponse['action'] === 'close') {
                                 self::log("Suspicious Login: Account challenge successful, please re-run the script!");
-                                exit();
+                                exit(1);
                             }
                         }
 
@@ -217,27 +217,24 @@ class Utils
                             ->getDecodedResponse();
 
                         if (@$customResponse['status'] === 'ok' && @$customResponse['logged_in_user']['pk'] !== null) {
-                            self::log("Suspicious Login: Account challenge successful, please re-run the script!");
-                            exit();
-                        } else {
-                            self::log("Suspicious Login: I have no clue if that just worked, re-run me to check.");
-                            exit();
+                            self::log("Suspicious Login: Challenge Probably Solved!");
+                            exit(1);
                         }
                     } catch (Exception $ex) {
                         self::log("Suspicious Login: Account Challenge Failed :(.");
                         self::dump($ex->getMessage());
-                        exit();
+                        exit(1);
                     }
                 }
             } catch (\LazyJsonMapper\Exception\LazyJsonMapperException $mapperException) {
                 self::log("Error While Logging in to Instagram: " . $e->getMessage());
                 self::dump();
-                exit();
+                exit(1);
             }
 
             self::log("Error While Logging in to Instagram: " . $e->getMessage());
             self::dump();
-            exit();
+            exit(1);
         }
         return $ig;
     }

--- a/utils.php
+++ b/utils.php
@@ -76,6 +76,15 @@ class Utils
     }
 
     /**
+     * Helper function to check if the current OS is Mac.
+     * @return bool Returns true if running Windows.
+     */
+    public static function isMac(): bool
+    {
+        return strtoupper(PHP_OS) === 'DARWIN';
+    }
+
+    /**
      * Logs message to a output file.
      * @param string $message message to be logged to file.
      * @param string $file file to output to.

--- a/utils.php
+++ b/utils.php
@@ -129,11 +129,13 @@ class Utils
      * Runs our login flow to authenticate the user as well as resolve all two-factor/challenge items.
      * @param string $username Username of the target account.
      * @param string $password Password of the target account.
+     * @param bool $debug Debug
+     * @param bool $truncatedDebug Truncated Debug
      * @return ExtendedInstagram Authenticated Session.
      */
-    public static function loginFlow($username, $password): ExtendedInstagram
+    public static function loginFlow($username, $password, $debug = false, $truncatedDebug = false): ExtendedInstagram
     {
-        $ig = new ExtendedInstagram(false, false);
+        $ig = new ExtendedInstagram($debug, $truncatedDebug);
         try {
             $loginResponse = $ig->login($username, $password);
 

--- a/utils.php
+++ b/utils.php
@@ -94,6 +94,26 @@ class Utils
         return (substr($haystack, 0, strlen($needle)) === $needle);
     }
 
+    /**
+     * Prompts for user input. (Note: Holds the current thread!)
+     * @param string $prompt The prompt for the input.
+     * @return string The collected input.
+     */
+    public static function promptInput($prompt = '>'): string
+    {
+        print "$prompt ";
+        $handle = fopen("php://stdin", "r");
+        $input = trim(fgets($handle));
+        fclose($handle);
+        return $input;
+    }
+
+    /**
+     * Runs our login flow to authenticate the user as well as resolve all two-factor/challenge items.
+     * @param string $username Username of the target account.
+     * @param string $password Password of the target account.
+     * @return ExtendedInstagram Authenticated Session.
+     */
     public static function loginFlow($username, $password): ExtendedInstagram
     {
         $ig = new ExtendedInstagram(false, false);
@@ -103,10 +123,7 @@ class Utils
             if ($loginResponse !== null && $loginResponse->isTwoFactorRequired()) {
                 self::log("Two-Factor Authentication Required! Please provide your verification code from your texts/other means.");
                 $twoFactorIdentifier = $loginResponse->getTwoFactorInfo()->getTwoFactorIdentifier();
-                print "\nType your verification code> ";
-                $handle = fopen("php://stdin", "r");
-                $verificationCode = trim(fgets($handle));
-                fclose($handle);
+                $verificationCode = self::promptInput("Type your verification code>");
                 self::log("Logging in with verification token...");
                 $ig->finishTwoFactorLogin($username, $password, $twoFactorIdentifier, $verificationCode);
             }
@@ -118,10 +135,7 @@ class Utils
 
                     self::log("Suspicious Login: Would you like to verify your account via text or email? Type \"yes\" or just press enter to ignore.");
                     self::log("Suspicious Login: Please only attempt this once or twice if your attempts are unsuccessful. If this keeps happening, this script is not for you :(.");
-                    print "> ";
-                    $handle = fopen("php://stdin", "r");
-                    $attemptBypass = trim(fgets($handle));
-                    fclose($handle);
+                    $attemptBypass = self::promptInput();
                     if ($attemptBypass !== 'yes') {
                         self::log("Suspicious Login: Account Challenge Failed :(.");
                         self::dump();
@@ -131,10 +145,7 @@ class Utils
                     sleep(3);
 
                     self::log("Suspicious Login: Please select your verification option by typing \"sms\" or \"email\" respectively. Otherwise press enter to abort.");
-                    print "> ";
-                    $handle = fopen("php://stdin", "r");
-                    $choice = trim(fgets($handle));
-                    fclose($handle);
+                    $choice = self::promptInput();
                     if ($choice === "sms") {
                         $verification_method = 0;
                     } elseif ($choice === "email") {
@@ -165,10 +176,7 @@ class Utils
                         }
 
                         self::log("Please enter the code you received via " . ($verification_method ? 'email' : 'sms') . "...");
-                        print "> ";
-                        $handle = fopen("php://stdin", "r");
-                        $cCode = trim(fgets($handle));
-                        fclose($handle);
+                        $cCode = self::promptInput();
                         $ig->changeUser($username, $password);
                         $customResponse = $ig->request($checkApiPath)
                             ->setNeedsAuth(false)

--- a/utils.php
+++ b/utils.php
@@ -62,10 +62,11 @@ class Utils
     /**
      * Logs message to a output file.
      * @param string $message message to be logged to file.
+     * @param string $file file to output to.
      */
-    public static function logOutput($message)
+    public static function logOutput($message, $file = 'output.txt')
     {
-        file_put_contents('output.txt', $message . PHP_EOL, FILE_APPEND | LOCK_EX);
+        file_put_contents($file, $message . PHP_EOL, FILE_APPEND | LOCK_EX);
     }
 
     /**
@@ -217,10 +218,14 @@ class Utils
     /**
      * Logs a message in console but it actually uses new lines.
      * @param string $message message to be logged.
+     * @param string $outputFile
      */
-    public static function log($message)
+    public static function log($message, $outputFile = '')
     {
         print $message . "\n";
+        if ($outputFile !== '') {
+            self::logOutput($message, $outputFile);
+        }
     }
 }
 


### PR DESCRIPTION
# About this Release
This release primarily adds a new script (`checkVod.php`) to check on your archived streams if you have any.

# Changelog
* Added macOS Live Chat Support
* Added `checkVod.php` script to view info on archived live streams and/or delete them
* Added final viewer count/names to the end of a broadcast
* Added `-d` command line argument to auto discard a stream
* Added OBS path and executable customization in `config.php`
* Removed `-d` as `--dump` alias
* Overhauled the README
* Improved the updater's speed
* Improved the update available message
* Increased the request cooldown to mitigate shadow bans
* Migrated authentication flow to a function in `Utils` class
* Migrated user input fetches to a function in `Utils` class
* Migrated to `require_once` from `require`
* Migrated to switch cases for commands
* Fixed a bug causing the updater to hang for a long time

# Test the Beta
To test the features in this beta, all you have to do is run your `update.php` with the `--beta` flag. (Like this: `php update.php --beta`)