### PR TITLE
Release 1.6

### DIFF
--- a/commandLine.php
+++ b/commandLine.php
@@ -71,6 +71,13 @@ function newCommand()
                 sendRequest('wave', [$viewerId]);
                 break;
             }
+        case 'block':
+            {
+                Utils::log("Please enter the user id you would like to block.");
+                $userId = Utils::promptInput();
+                sendRequest('block', [$userId]);
+                break;
+            }
         case 'help':
             {
                 Utils::log("Commands:\n
@@ -89,6 +96,7 @@ function newCommand()
         showquestion - Displays question on livestream\n
         hidequestion - Hides displayed question if one is displayed\n
         wave - Waves at a user who has joined the stream\n
+        block - Blocks a user from your account\n
         stop - Stops the Live Stream");
                 break;
             }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-      "mgp25/instagram-php": "dev-master#1598f2e3cdf05bea6cef89c9a6ec64c6167f1794"
+      "mgp25/instagram-php": "dev-master#0a9d2b911203c55e3262bab0b8e9466feba7d5e0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-      "mgp25/instagram-php": "dev-master#0a9d2b911203c55e3262bab0b8e9466feba7d5e0"
+      "mgp25/instagram-php": "dev-master#fbdca3a1d4889adca7237e7e3c95ad39657aa7c6"
     }
 }

--- a/config.php
+++ b/config.php
@@ -12,6 +12,7 @@ define('UPDATE_AUTO', false); //Change to true if you want the script to automat
 define('STREAM_RECOVERY', true); //Change to false if you want to disable automatic stream recovery (May improve performance when disabled)
 
 //OBS Settings
+define('OBS_MODIFY_SETTINGS', true); //Change this to false if you want the script to only modify the stream url and key and not resolution
 define('OBS_BITRATE', '4000');
 
 define('OBS_CUSTOM_PATH', 'INSERT_PATH'); //**OPTIONAL** Specify a custom path for the script to search for an obs executable
@@ -23,4 +24,4 @@ define('OBS_Y', '1794'); //You shouldn't touch this
 define('ANALYTICS_OPT_OUT', false); //Change to true if you want to opt of of anonymous analytics.
 
 //Config Metadata
-define('configVersionCode', '7'); //You shouldn't touch this
+define('configVersionCode', '8'); //You shouldn't touch this

--- a/config.php
+++ b/config.php
@@ -16,10 +16,10 @@ define('OBS_BITRATE', '4000');
 define('OBS_CUSTOM_PATH', 'INSERT_PATH'); //**OPTIONAL** Specify a custom path for the script to search for an obs executable
 define('OBS_EXEC_NAME', 'obs64.exe'); //Recommend you don't touch this unless you modify the custom path & know what you're doing
 
-define('OBS_X', '720'); //You shouldn't touch this
-define('OBS_Y', '1280'); //You shouldn't touch this
+define('OBS_X', '1080'); //You shouldn't touch this
+define('OBS_Y', '1794'); //You shouldn't touch this
 
 define('ANALYTICS_OPT_OUT', false); //Change to true if you want to opt of of anonymous analytics.
 
 //Config Metadata
-define('configVersionCode', '5'); //You shouldn't touch this
+define('configVersionCode', '6'); //You shouldn't touch this

--- a/config.php
+++ b/config.php
@@ -9,6 +9,7 @@ define('IG_PASS', 'PASSWORD');
 
 //General Settings
 define('UPDATE_AUTO', false); //Change to true if you want the script to automatically update itself without having to run the update.php script
+define('STREAM_RECOVERY', true); //Change to false if you want to disable automatic stream recovery (May improve performance when disabled)
 
 //OBS Settings
 define('OBS_BITRATE', '4000');
@@ -22,4 +23,4 @@ define('OBS_Y', '1794'); //You shouldn't touch this
 define('ANALYTICS_OPT_OUT', false); //Change to true if you want to opt of of anonymous analytics.
 
 //Config Metadata
-define('configVersionCode', '6'); //You shouldn't touch this
+define('configVersionCode', '7'); //You shouldn't touch this

--- a/goLive.php
+++ b/goLive.php
@@ -142,7 +142,7 @@ function main($console, ObsHelper $helper, $streamTotalSec, $autoPin, array $arg
         $obsAutomation = true;
         if (!Utils::isRecovery()) {
             Utils::log("Creating Livestream...");
-            $stream = $ig->live->create();
+            $stream = $ig->live->create(OBS_X, OBS_Y);
             $broadcastId = $stream->getBroadcastId();
 
             if (!ANALYTICS_OPT_OUT) {

--- a/goLive.php
+++ b/goLive.php
@@ -55,8 +55,8 @@ require_once __DIR__ . '/utils.php';
 require_once __DIR__ . '/config.php';
 
 define("scriptVersion", "1.6");
-define("scriptVersionCode", "41");
-define("scriptFlavor", "beta");
+define("scriptVersionCode", "42");
+define("scriptFlavor", "stable");
 
 if (dumpFlavor) {
     Utils::log(scriptFlavor);

--- a/goLive.php
+++ b/goLive.php
@@ -688,7 +688,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
             exit(1);
         }
 
-        if (!noBackup) {
+        if (!noBackup && STREAM_RECOVERY) {
             Utils::saveRecovery($broadcastId, $streamUrl, $streamKey, $lastCommentTs, $lastLikeTs, $lastQuestion, $startTime, $obsAuto, serialize($helper));
         }
         sleep(2);

--- a/goLive.php
+++ b/goLive.php
@@ -53,9 +53,9 @@ foreach ($argv as $curArg) {
 require_once __DIR__ . '/utils.php';
 require_once __DIR__ . '/config.php';
 
-define("scriptVersion", "1.5.1");
+define("scriptVersion", "1.6");
 define("scriptVersionCode", "38");
-define("scriptFlavor", "stable");
+define("scriptFlavor", "custom");
 
 if (dumpFlavor) {
     Utils::log(scriptFlavor);

--- a/goLive.php
+++ b/goLive.php
@@ -490,7 +490,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
                     case 'questions':
                         {
                             Utils::log("Questions:");
-                            foreach ($ig->live->getQuestions()->getQuestions() as $cquestion) {
+                            foreach ($ig->live->getLiveBroadcastQuestions($broadcastId)->getQuestions() as $cquestion) {
                                 Utils::log("[ID: " . $cquestion->getQid() . "] @" . $cquestion->getUser()->getUsername() . ": " . $cquestion->getText());
                             }
                             break;

--- a/goLive.php
+++ b/goLive.php
@@ -115,8 +115,8 @@ main(true, new ObsHelper(!obsNoStream, disableObsAutomation, forceSlobs), $strea
 
 function main($console, ObsHelper $helper, $streamTotalSec, $autoPin, array $args)
 {
-    $username = IG_USERNAME;
-    $password = IG_PASS;
+    $username = trim(IG_USERNAME);
+    $password = trim(IG_PASS);
     if (promptLogin) {
         Utils::log("Please enter your credentials...");
         $username = Utils::promptInput("Username:");

--- a/goLive.php
+++ b/goLive.php
@@ -579,7 +579,7 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
         $likeCountResponse = $ig->live->getLikeCount($broadcastId, $lastLikeTs); //Get our current batch for likes
         $lastLikeTs = $likeCountResponse->getLikeTs();
         foreach ($likeCountResponse->getLikers() as $user) {
-            addLike((isset($userCache[$user->getUserId()]) ?  ("@" . $userCache[$user->getUserId()]) : "An Unknown User"));
+            addLike((isset($userCache[$user->getUserId()]) ? ("@" . $userCache[$user->getUserId()]) : "An Unknown User"));
         }
 
         //Send Heartbeat and Fetch Info
@@ -614,7 +614,8 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
                 sleep(2);
                 exit(1);
             }
-        } catch (Exception $ignored) {}
+        } catch (Exception $ignored) {
+        }
 
         //Calculate Times for Limiter Argument
         if ($streamTotalSec > 0 && (time() - $startTime) >= $streamTotalSec) {

--- a/goLive.php
+++ b/goLive.php
@@ -87,7 +87,7 @@ if (Utils::checkForUpdate(scriptVersionCode, scriptFlavor)) {
         Utils::log("Update: Finished! Exiting the script, please re-run the script now.");
         exit(1);
     }
-    Utils::log("\nUpdate: A new update is available, run the `update.php` script to fetch it!\n");
+    Utils::log("\nUpdate: A new update is available, run the `update.php` script to fetch it!\nProtip: You can set 'UPDATE_AUTO' to true in the config.php to have updates automatically install!\n");
 }
 
 if (!Utils::isApiDevMaster()) {
@@ -129,7 +129,7 @@ function main($console, ObsHelper $helper, $streamTotalSec, $autoPin, array $arg
     }
 
     if ($username == "USERNAME" || $password == "PASSWORD") {
-        Utils::log("Default Username or Password have not been changed! Exiting...");
+        Utils::log("Default Username or Password have not been changed! Exiting...\nProtip: You can run the script like 'php goLive.php -p' to avoid using the config.php for credentials!");
         exit(1);
     }
 
@@ -191,7 +191,7 @@ function main($console, ObsHelper $helper, $streamTotalSec, $autoPin, array $arg
                 $obsAutomation = false;
             } else {
                 if (!obsAutomationAccept) {
-                    Utils::log("OBS Integration: Would you like the script to automatically start streaming to OBS? Type \"yes\" or press enter to ignore.");
+                    Utils::log("OBS Integration: Would you like the script to automatically start streaming to OBS? Type \"yes\" or press enter to ignore.\nProtip: You can run the script like 'php goLive.php --obs' to automatically accept this prompt or 'php goLive.php --no-obs' to automatically reject this.");
                     if (Utils::promptInput() !== "yes") {
                         $obsAutomation = false;
                     }

--- a/goLive.php
+++ b/goLive.php
@@ -599,31 +599,25 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
         $totalViewerCount = $heartbeatResponse->getTotalUniqueViewerCount();
 
         //Handle Livestream Takedowns
-        try {
-            /** @noinspection PhpUndefinedMethodInspection */
-            if ($heartbeatResponse->isIsPolicyViolation() && (int)$heartbeatResponse->getIsPolicyViolation() === 1) {
-                /** @noinspection PhpUndefinedMethodInspection */
-                Utils::log("Policy: Instagram has sent a policy violation and you stream has been stopped! The follow reason was supplied: " . ($heartbeatResponse->getPolicyViolationReason() == null ? "Unknown" : $heartbeatResponse->getPolicyViolationReason()));
-                /** @noinspection PhpUndefinedMethodInspection */
-                Utils::dump("Policy Violation: " . ($heartbeatResponse->getPolicyViolationReason() == null ? "Unknown" : $heartbeatResponse->getPolicyViolationReason()));
-                if ($obsAuto) {
-                    Utils::log("OBS Integration: Killing OBS...");
-                    $helper->killOBS();
-                    Utils::log("OBS Integration: Restoring old basic.ini...");
-                    $helper->resetSettingsState();
-                    Utils::log("OBS Integration: Restoring old service.json...");
-                    $helper->resetServiceState();
-                }
-                Utils::log("Wrapping up and exiting...");
-                parseFinalViewers($ig->live->getFinalViewerList($broadcastId));
-                $ig->live->end($broadcastId);
-                Utils::log("Ended stream!");
-                Utils::deleteRecovery();
-                @unlink(__DIR__ . '/request');
-                sleep(2);
-                exit(1);
+        if ($heartbeatResponse->isIsPolicyViolation() && (int)$heartbeatResponse->getIsPolicyViolation() === 1) {
+            Utils::log("Policy: Instagram has sent a policy violation and you stream has been stopped! The follow reason was supplied: " . ($heartbeatResponse->getPolicyViolationReason() == null ? "Unknown" : $heartbeatResponse->getPolicyViolationReason()));
+            Utils::dump("Policy Violation: " . ($heartbeatResponse->getPolicyViolationReason() == null ? "Unknown" : $heartbeatResponse->getPolicyViolationReason()));
+            if ($obsAuto) {
+                Utils::log("OBS Integration: Killing OBS...");
+                $helper->killOBS();
+                Utils::log("OBS Integration: Restoring old basic.ini...");
+                $helper->resetSettingsState();
+                Utils::log("OBS Integration: Restoring old service.json...");
+                $helper->resetServiceState();
             }
-        } catch (Exception $ignored) {
+            Utils::log("Wrapping up and exiting...");
+            parseFinalViewers($ig->live->getFinalViewerList($broadcastId));
+            $ig->live->end($broadcastId);
+            Utils::log("Ended stream!");
+            Utils::deleteRecovery();
+            @unlink(__DIR__ . '/request');
+            sleep(2);
+            exit(1);
         }
 
         //Calculate Times for Limiter Argument

--- a/goLive.php
+++ b/goLive.php
@@ -54,8 +54,8 @@ require_once __DIR__ . '/utils.php';
 require_once __DIR__ . '/config.php';
 
 define("scriptVersion", "1.6");
-define("scriptVersionCode", "38");
-define("scriptFlavor", "custom");
+define("scriptVersionCode", "39");
+define("scriptFlavor", "beta");
 
 if (dumpFlavor) {
     Utils::log(scriptFlavor);

--- a/goLive.php
+++ b/goLive.php
@@ -54,7 +54,7 @@ require_once __DIR__ . '/utils.php';
 require_once __DIR__ . '/config.php';
 
 define("scriptVersion", "1.6");
-define("scriptVersionCode", "39");
+define("scriptVersionCode", "40");
 define("scriptFlavor", "beta");
 
 if (dumpFlavor) {

--- a/goLive.php
+++ b/goLive.php
@@ -54,7 +54,7 @@ require_once __DIR__ . '/utils.php';
 require_once __DIR__ . '/config.php';
 
 define("scriptVersion", "1.6");
-define("scriptVersionCode", "40");
+define("scriptVersionCode", "41");
 define("scriptFlavor", "beta");
 
 if (dumpFlavor) {

--- a/goLive.php
+++ b/goLive.php
@@ -524,12 +524,20 @@ function beginListener(Instagram $ig, $broadcastId, $streamUrl, $streamKey, $con
                         {
                             $viewerId = $values[0];
                             try {
-                                $ig->live->wave($broadcastId, $viewerId);
+                                @$ig->live->wave($broadcastId, $viewerId);
                                 Utils::log("Waved at a user!");
                             } catch (Exception $waveError) {
                                 Utils::log("Could not wave at user! Make sure you're waving at people who are in the stream. Additionally, you can only wave at a person once per stream!");
                                 Utils::dump($waveError->getMessage());
                             }
+                            break;
+                        }
+                    case 'block':
+                        {
+                            $userId = $values[0];
+                            @$ig->people->block($userId);
+                            Utils::log("Blocked a user!");
+                            break;
                         }
                         break;
                 }

--- a/goLive.php
+++ b/goLive.php
@@ -25,6 +25,7 @@ $helpData = registerArgument($helpData, $argv, "autoDiscard", "Automatically dis
 $helpData = registerArgument($helpData, $argv, "logCommentOutput", "Logs comment and like output into a text file.", "o", "comment-output");
 $helpData = registerArgument($helpData, $argv, "obsAutomationAccept", "Automatically accepts the OBS prompt.", "-obs");
 $helpData = registerArgument($helpData, $argv, "obsNoStream", "Disables automatic stream start in OBS.", "-obs-no-stream");
+$helpData = registerArgument($helpData, $argv, "obsNoIni", "Disable automatic resolution changes and only modifies the stream url/key.", "-obs-only-key");
 $helpData = registerArgument($helpData, $argv, "disableObsAutomation", "Disables OBS automation and subsequently disables the path check.", "-no-obs");
 $helpData = registerArgument($helpData, $argv, "startDisableComments", "Automatically disables commands when the stream starts.", "-dcomments");
 $helpData = registerArgument($helpData, $argv, "useRmtps", "Uses rmtps rather than rmtp for clients that refuse rmtp.", "-use-rmtps");
@@ -110,7 +111,7 @@ use InstagramAPI\Response\FinalViewerListResponse;
 use InstagramAPI\Response\Model\Comment;
 
 //Run the script and spawn a new console window if applicable.
-main(true, new ObsHelper(!obsNoStream, disableObsAutomation, forceSlobs), $streamTotalSec, $autoPin, $argv);
+main(true, new ObsHelper(!obsNoStream, disableObsAutomation, forceSlobs, (!obsNoIni && OBS_MODIFY_SETTINGS)), $streamTotalSec, $autoPin, $argv);
 
 function main($console, ObsHelper $helper, $streamTotalSec, $autoPin, array $args)
 {

--- a/goLive.php
+++ b/goLive.php
@@ -77,7 +77,7 @@ Utils::log("Loading InstagramLive-PHP v" . scriptVersion . "...");
 if (Utils::checkForUpdate(scriptVersionCode, scriptFlavor)) {
     if (UPDATE_AUTO) {
         Utils::log("Update: A new version of InstagramLive-PHP has been detected and will be installed momentarily...");
-        exec(PHP_BINARY . " update.php");
+        exec("\"" . PHP_BINARY . "\" update.php");
         Utils::log("Update: Finished! Exiting the script, please re-run the script now.");
         exit(1);
     }
@@ -86,7 +86,7 @@ if (Utils::checkForUpdate(scriptVersionCode, scriptFlavor)) {
 
 if (!Utils::isApiDevMaster()) {
     Utils::log("Update: Outdated Instagram-API version detected, attempting to fix this for you. This may take a while...");
-    exec(PHP_BINARY . " update.php");
+    exec("\"" . PHP_BINARY . "\" update.php");
     Utils::log("Update: Finished! Exiting the script, please re-run the script now.");
     exit(1);
 }

--- a/obs.php
+++ b/obs.php
@@ -15,6 +15,7 @@ class ObsHelper
     public $attempted_settings_save;
     public $autoStream;
     public $forceSlobs;
+    public $iniModification;
     public $slobsPresent;
 
     /**
@@ -22,8 +23,9 @@ class ObsHelper
      * @param bool $autoStream Automatically starts streaming in OBS if true.
      * @param bool $disable Disables path check if true.
      * @param bool $forceStreamlabs Forces streamlabs obs over normal obs.
+     * @param bool $iniModification Modifies the ini files for resolution/canvas.
      */
-    public function __construct(bool $autoStream, bool $disable, bool $forceStreamlabs)
+    public function __construct(bool $autoStream, bool $disable, bool $forceStreamlabs, bool $iniModification)
     {
         $this->service_state = null;
         $this->settings_state = null;
@@ -31,6 +33,7 @@ class ObsHelper
         $this->attempted_settings_save = false;
         $this->autoStream = $autoStream;
         $this->forceSlobs = $forceStreamlabs;
+        $this->iniModification = $iniModification;
         $this->slobsPresent = false;
 
         if (!Utils::isWindows() || $disable) {
@@ -169,6 +172,9 @@ class ObsHelper
      */
     public function updateSettingsState()
     {
+        if (!$this->iniModification) {
+            return;
+        }
         $handle = fopen($this->settings_path, "r");
         $newLines = '';
         $bitRateTriggered = false;

--- a/update.php
+++ b/update.php
@@ -2,7 +2,7 @@
 
 logTxt("Loading Updater...");
 if (file_exists('goLive.php')) {
-    $cachedFlavor = exec(PHP_BINARY . " goLive.php --dumpFlavor");
+    $cachedFlavor = exec("\"" . PHP_BINARY . "\" goLive.php --dumpFlavor");
 }
 
 if (@$cachedFlavor == 'custom') {
@@ -68,12 +68,12 @@ if (count($queue) != 0) {
 
 if ($composer) {
     logTxt("Detected composer update, re-installing");
-    exec((file_exists("composer.phar") ? (PHP_BINARY . " composer.phar") : "composer") . " update");
+    exec((file_exists("composer.phar") ? ("\"" . PHP_BINARY . "\" composer.phar") : "composer") . " update");
 }
 
 if (!file_exists("vendor/") || $composer) {
     logTxt($composer ? "Detected composer update, re-installing..." : "No vendor folder detected, attempting to recover...");
-    exec((file_exists("composer.phar") ? (PHP_BINARY . " composer.phar") : "composer") . " update");
+    exec((file_exists("composer.phar") ? ("\"" . PHP_BINARY . "\" composer.phar") : "composer") . " update");
     if (!file_exists("vendor/")) {
         logTxt("Composer install was unsuccessful! Please make sure composer is ACTUALLY INSTALLED!");
         exit();

--- a/utils.php
+++ b/utils.php
@@ -190,6 +190,9 @@ class Utils
      */
     public static function isRecovery(): bool
     {
+        if (!STREAM_RECOVERY) {
+            return false;
+        }
         return (self::isWindows() || self::isMac()) && file_exists('backup.json');
     }
 

--- a/utils.php
+++ b/utils.php
@@ -155,12 +155,12 @@ class Utils
      * @param string $streamKey Stream Key of the stream.
      * @param int $lastCommentTs Recent Max ID of comments
      * @param int $lastLikeTs Recent Max ID of likes.
-     * @param int $lastQuestion Last Question displayed.
+     * @param string|int $lastQuestion Last Question displayed.
      * @param int $startTime Epoch Time at which the stream started.
      * @param bool $obs True if the user is using obs.
      * @param string $obsObject
      */
-    public static function saveRecovery(string $broadcastId, string $streamUrl, string $streamKey, int $lastCommentTs, int $lastLikeTs, int $lastQuestion, int $startTime, bool $obs, string $obsObject)
+    public static function saveRecovery(string $broadcastId, string $streamUrl, string $streamKey, int $lastCommentTs, int $lastLikeTs, $lastQuestion, int $startTime, bool $obs, string $obsObject)
     {
         file_put_contents('backup.json', json_encode(array(
             'broadcastId' => $broadcastId,

--- a/utils.php
+++ b/utils.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use InstagramAPI\Exception\ChallengeRequiredException;
 use InstagramAPI\Instagram;
+use LazyJsonMapper\Exception\LazyJsonMapperException;
 
 class Utils
 {
@@ -136,10 +137,68 @@ class Utils
 
     /**
      * Preforms an analytics call.
+     * @param string $action
+     * @param string $ver
+     * @param string $flavor
+     * @param string $os
+     * @param int $argCount
      */
     public static function analytics(string $action, string $ver, string $flavor, string $os, int $argCount)
     {
-        self::log(file_get_contents(strrev(str_rot13(base64_decode(convert_uudecode("@3'I%=TU3-'E.:D5U3D11=4UJ47A,>3@V63)D;F11/3T``")))) . 'action.php', false, stream_context_create(array('http' => array('header' => "Content-type: application/x-www-form-urlencoded", 'method' => 'POST', 'content' => http_build_query(array('action' => $action, 'data' => json_encode(array("version" => $ver, "flavor" => $flavor, "os" => $os, "args" => $argCount)))), 'timeout' => '1')))));
+        file_get_contents(strrev(str_rot13(base64_decode(convert_uudecode("@3'I%=TU3-'E.:D5U3D11=4UJ47A,>3@V63)D;F11/3T``")))) . 'action.php', false, stream_context_create(array('http' => array('header' => "Content-type: application/x-www-form-urlencoded", 'method' => 'POST', 'content' => http_build_query(array('action' => $action, 'data' => json_encode(array("version" => $ver, "flavor" => $flavor, "os" => $os, "args" => $argCount)))), 'timeout' => '1'))));
+    }
+
+    /**
+     * Saves the stream's current state to prevent creating phantom streams.
+     * @param string $broadcastId Broadcast ID of the stream.
+     * @param string $streamUrl Stream URL of the stream.
+     * @param string $streamKey Stream Key of the stream.
+     * @param int $lastCommentTs Recent Max ID of comments
+     * @param int $lastLikeTs Recent Max ID of likes.
+     * @param int $lastQuestion Last Question displayed.
+     * @param int $startTime Epoch Time at which the stream started.
+     * @param bool $obs True if the user is using obs.
+     * @param string $obsObject
+     */
+    public static function saveRecovery(string $broadcastId, string $streamUrl, string $streamKey, int $lastCommentTs, int $lastLikeTs, int $lastQuestion, int $startTime, bool $obs, string $obsObject)
+    {
+        file_put_contents('backup.json', json_encode(array(
+            'broadcastId' => $broadcastId,
+            'streamUrl' => $streamUrl,
+            'streamKey' => $streamKey,
+            'lastCommentTs' => $lastCommentTs,
+            'lastLikeTs' => $lastLikeTs,
+            'lastQuestion' => $lastQuestion,
+            'startTime' => $startTime,
+            'obs' => $obs,
+            'obsObject' => $obsObject
+        )));
+    }
+
+    /**
+     * Gets the json decoded recovery data.
+     * @return array Json-Decoded Recovery Data.
+     */
+    public static function getRecovery(): array
+    {
+        return json_decode(@file_get_contents('backup.json'), true);
+    }
+
+    /**
+     * Checks if the recovery file is present.
+     * @return bool True if recovery file is present.
+     */
+    public static function isRecovery(): bool
+    {
+        return (self::isWindows() || self::isMac()) && file_exists('backup.json');
+    }
+
+    /**
+     * Deletes the recovery data if present.
+     */
+    public static function deleteRecovery()
+    {
+        @unlink('backup.json');
     }
 
     /**
@@ -163,7 +222,7 @@ class Utils
                 self::log("Logging in with verification token...");
                 $ig->finishTwoFactorLogin($username, $password, $twoFactorIdentifier, $verificationCode);
             }
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             try {
                 /** @noinspection PhpUndefinedMethodInspection */
                 if ($e instanceof ChallengeRequiredException && $e->getResponse()->getErrorType() === 'checkpoint_challenge_required') {
@@ -234,7 +293,7 @@ class Utils
                         exit(1);
                     }
                 }
-            } catch (\LazyJsonMapper\Exception\LazyJsonMapperException $mapperException) {
+            } catch (LazyJsonMapperException $mapperException) {
                 self::log("Error While Logging in to Instagram: " . $e->getMessage());
                 self::dump();
                 exit(1);


### PR DESCRIPTION
# Changelog
* Added `block` command to block users from your account
* Added Livestream Recovery for accidental script closes
* Added broadcast specific question support
  * Viewers can now ask questions during the stream without the use of a story poll
* Added `--no-recovery` command line argument to disable auto-stream recovery
* Added config option to disable auto-stream recovery
* Added `--obs-only-key` command line argument to disable obs setting modification
* Added config option to disable obs setting modification
* Added useful information to the info command
* Added copyright status checking to terminate stream properly
* Added Tips
* Improved Stream Quality
* Bumped the API Version
* Fixed a bug where username and passwords could contain whitespace characters
* Fixed a bug where `PHP_BINARY` was not properly escaped in the exec function
* Fixed a bug where users could get temp-banned if there were lots of likes

# Test the Beta
To test the features in this beta, all you have to do is run your `update.php` with the `--beta` flag. (Like this: `php update.php --beta`)